### PR TITLE
Disable start/stop controls

### DIFF
--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -353,9 +353,5 @@ socket.on('bot_status', function(data) {
         monitoringStatus.textContent = `${data.monitored_count} / ${data.total_markets}`;
     }
 
-    // 버튼 상태 업데이트
-    const startButton = document.getElementById('start-bot');
-    const stopButton = document.getElementById('stop-bot');
-    if (startButton) startButton.disabled = data.status;
-    if (stopButton) stopButton.disabled = !data.status;
+    // 버튼 상태 업데이트는 사용하지 않습니다. 항상 비활성화 상태로 유지합니다.
 }); 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -4,6 +4,9 @@ const socket = io();
 // DOM 요소
 const botStatus = document.getElementById('bot-status');
 const startBotButton = document.getElementById('toggleBot');
+if (startBotButton) {
+    startBotButton.disabled = true;
+}
 const monitoredCoinsTable = document.getElementById('monitored-coins');
 const holdingsTable = document.getElementById('holdingsTableBody');
 const statusIndicator = document.getElementById('botStatus');
@@ -243,12 +246,7 @@ function sellCoin(market) {
     }
 }
 
-// 시작/중지 버튼 이벤트 리스너
-startBotButton.addEventListener('click', function() {
-    const isRunning = this.textContent.trim() === '중지';
-    console.log('버튼 클릭:', isRunning ? 'stop_bot' : 'start_bot');
-    socket.emit(isRunning ? 'stop_bot' : 'start_bot');
-});
+// 시작/중지 버튼은 비활성화되어 있습니다.
 
 // 페이지 로드 시 초기 데이터 요청
 socket.emit('request_initial_data');

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -110,10 +110,10 @@
                 <div class="row mt-3">
                     <div class="col-12">
                         <div class="d-flex justify-content-center">
-                            <button id="start-bot" class="btn btn-success me-2">
+                            <button id="start-bot" class="btn btn-secondary me-2" disabled>
                                 <i class="fas fa-play"></i> 시작
                             </button>
-                            <button id="stop-bot" class="btn btn-danger" disabled>
+                            <button id="stop-bot" class="btn btn-secondary" disabled>
                                 <i class="fas fa-stop"></i> 중지
                             </button>
                         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -154,7 +154,7 @@
                                 <span class="fw-bold">상태:</span>
                                 <span id="botStatus" class="badge bg-secondary ms-2">중지됨</span>
                             </div>
-                            <button id="toggleBot" class="btn btn-primary">시작</button>
+                            <button id="toggleBot" class="btn btn-secondary" disabled>시작</button>
                         </div>
                         <div class="market-status">
                             <div class="mb-2">
@@ -402,14 +402,14 @@
             if (status) {
                 statusBadge.className = 'badge bg-success ms-2';
                 statusBadge.textContent = message || '실행 중';
-                toggleButton.textContent = '중지';
-                toggleButton.className = 'btn btn-danger';
             } else {
                 statusBadge.className = 'badge bg-secondary ms-2';
                 statusBadge.textContent = message || '중지됨';
-                toggleButton.textContent = '시작';
-                toggleButton.className = 'btn btn-primary';
             }
+
+            // 버튼은 항상 비활성화된 회색 상태로 유지합니다.
+            toggleButton.className = 'btn btn-secondary';
+            toggleButton.disabled = true;
         }
 
         // 보유 코인 테이블 업데이트 함수
@@ -525,24 +525,7 @@
         document.addEventListener('DOMContentLoaded', () => {
             initializeSocket();
             
-            // 시작/중지 버튼 이벤트 리스너
-            const toggleButton = document.getElementById('toggleBot');
-            if (toggleButton) {
-                toggleButton.addEventListener('click', () => {
-                    if (!socket) {
-                        showNotification('서버에 연결할 수 없습니다.', 'error');
-                        return;
-                    }
-                    
-                    const event = isRunning ? 'stop_bot' : 'start_bot';
-                    console.log('Emitting event:', event);
-                    socket.emit(event, {}, (response) => {
-                        if (response && response.error) {
-                            showNotification(response.error, 'error');
-                        }
-                    });
-                });
-            }
+            // 시작/중지 버튼은 비활성화되어 있으므로 이벤트 리스너를 등록하지 않습니다.
 
             // 페이지 로드 시 초기 데이터 요청
             socket.emit('request_initial_data');


### PR DESCRIPTION
## Summary
- disable bot control buttons in dashboard and index templates
- prevent start/stop events from main.js and dashboard.js

## Testing
- `pytest -q` *(fails: KeyError in config tests and assertions in trading state tests)*

------
https://chatgpt.com/codex/tasks/task_e_6847a05d3b388329b549d8df0bbb00ed