### PR TITLE
Fix socket.io initialization for fallback polling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -293,8 +293,6 @@
             }
 
             socket = io({
-                transports: ['websocket'],
-                upgrade: false,
                 reconnection: true,
                 reconnectionAttempts: MAX_RECONNECT_ATTEMPTS,
                 reconnectionDelay: 1000,


### PR DESCRIPTION
## Summary
- avoid websocket-only connections on the home page

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6847a60af45c8329af5fa7bd8343649c