### PR TITLE
Organize settings page cards

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -243,6 +243,51 @@
                     </div>
                 </div>
 
+
+                <!-- 알림 설정 -->
+                <div class="card">
+                    <div class="card-header">
+                        <h5 class="card-title mb-0">알림 설정</h5>
+                    </div>
+                    <div class="card-body">
+                        <div class="mb-3">
+                            <label class="form-label">매매 알림</label>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="notifications.trade.start">
+                                <label class="form-check-label">매매 시작</label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="notifications.trade.complete">
+                                <label class="form-check-label">매매 완료</label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="notifications.trade.profit_loss">
+                                <label class="form-check-label">수익/손실</label>
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label class="form-label">시스템 알림</label>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="notifications.system.error">
+                                <label class="form-check-label">오류</label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="notifications.system.daily_summary">
+                                <label class="form-check-label">일일 요약</label>
+                            </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="notifications.system.signal">
+                                <label class="form-check-label">시그널</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+
+            <!-- 오른쪽 열 -->
+            <div class="right-column">
                 <!-- 매수 지표 설정 -->
                 <div class="card">
                     <div class="card-header">
@@ -363,10 +408,7 @@
                         </div>
                     </div>
                 </div>
-            </div>
 
-            <!-- 오른쪽 열 -->
-            <div class="right-column">
                 <!-- 매도 조건 설정 -->
                 <div class="card">
                     <div class="card-header">
@@ -498,45 +540,6 @@
                     </div>
                 </div>
 
-                <!-- 알림 설정 -->
-                <div class="card">
-                    <div class="card-header">
-                        <h5 class="card-title mb-0">알림 설정</h5>
-                    </div>
-                    <div class="card-body">
-                        <div class="mb-3">
-                            <label class="form-label">매매 알림</label>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="notifications.trade.start">
-                                <label class="form-check-label">매매 시작</label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="notifications.trade.complete">
-                                <label class="form-check-label">매매 완료</label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="notifications.trade.profit_loss">
-                                <label class="form-check-label">수익/손실</label>
-                            </div>
-                        </div>
-
-                        <div class="mb-3">
-                            <label class="form-label">시스템 알림</label>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="notifications.system.error">
-                                <label class="form-check-label">오류</label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="notifications.system.daily_summary">
-                                <label class="form-check-label">일일 요약</label>
-                            </div>
-                            <div class="form-check">
-                                <input class="form-check-input" type="checkbox" id="notifications.system.signal">
-                                <label class="form-check-label">시그널</label>
-                            </div>
-                        </div>
-                    </div>
-                </div>
             </div>
         </div>
 


### PR DESCRIPTION
## Summary
- rearrange `settings.html` layout to group cards by theme
- left column: basic settings and notifications
- right column: buy and sell condition settings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*
- `python -m unittest discover -v tests` *(fails: ModuleNotFoundError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847a5a05f1c832984a269b60c884f16