### PR TITLE
Add 1m strategy and bullish filter

### DIFF
--- a/config/default_settings.py
+++ b/config/default_settings.py
@@ -87,6 +87,7 @@ DEFAULT_SETTINGS = {
             },
             "enabled": {
                 "trend_filter": True,
+                "bull_filter": False,
                 "golden_cross": True,
                 "rsi": True,
                 "bollinger": True,

--- a/config/settings.json
+++ b/config/settings.json
@@ -41,6 +41,7 @@
             },
             "enabled": {
                 "trend_filter": false,
+                "bull_filter": false,
                 "golden_cross": false,
                 "rsi": false,
                 "bollinger": false,

--- a/trading/bot/trading_bot.py
+++ b/trading/bot/trading_bot.py
@@ -2,7 +2,7 @@ import time
 from typing import Dict, List, Optional
 from core.upbit_api import UpbitAPI
 from ..data.market_data import MarketData
-from ..strategies.five_min_strategy import FiveMinStrategy
+from ..strategies.one_min_strategy import OneMinStrategy
 from ..utils.logger import TradingLogger
 
 class TradingBot:
@@ -24,7 +24,7 @@ class TradingBot:
         self.market_data = MarketData(self.exchange, settings)
         
         # 전략 초기화
-        self.strategy = FiveMinStrategy(settings)
+        self.strategy = OneMinStrategy(settings)
         
         # 실행 상태
         self.is_running = False
@@ -79,12 +79,12 @@ class TradingBot:
         """보유 중인 코인의 매도 신호 확인"""
         for symbol in list(self.strategy.positions.keys()):
             try:
-                df_5m = self.market_data.get_data(symbol, "5m")
-                if df_5m is None or df_5m.empty:
+                df_1m = self.market_data.get_data(symbol, "1m")
+                if df_1m is None or df_1m.empty:
                     continue
                     
                 # 매도 신호 확인
-                if self.strategy.check_sell_signal(symbol, df_5m):
+                if self.strategy.check_sell_signal(symbol, df_1m):
                     position = self.strategy.positions[symbol]
                     
                     # 시장가 매도 실행
@@ -116,14 +116,14 @@ class TradingBot:
                     continue
                     
                 # 시장 데이터 조회
-                df_5m = self.market_data.get_data(symbol, "5m")
+                df_1m = self.market_data.get_data(symbol, "1m")
                 df_15m = self.market_data.get_data(symbol, "15m")
-                
-                if df_5m is None or df_15m is None or df_5m.empty or df_15m.empty:
+
+                if df_1m is None or df_15m is None or df_1m.empty or df_15m.empty:
                     continue
                     
                 # 매수 신호 확인
-                if self.strategy.check_buy_signal(df_5m, df_15m):
+                if self.strategy.check_buy_signal(df_1m, df_15m):
                     # 시장가 매수 실행
                     order = self.exchange.buy_market_order(symbol, investment_amount)
                     if order:

--- a/trading/data/market_data.py
+++ b/trading/data/market_data.py
@@ -33,6 +33,13 @@ class MarketData:
             symbol: 심볼
         """
         try:
+            # 1분봉 데이터 업데이트
+            df_1m = self.exchange.get_ohlcv(symbol, "minute1", 100)
+            if df_1m is not None:
+                if symbol not in self.data_cache:
+                    self.data_cache[symbol] = {}
+                self.data_cache[symbol]["1m"] = df_1m
+
             # 5분봉 데이터 업데이트
             df_5m = self.exchange.get_ohlcv(symbol, "minute5", 100)
             if df_5m is not None:
@@ -84,7 +91,7 @@ class MarketData:
         캐시된 시장 데이터 조회
         Args:
             symbol: 심볼
-            interval: 시간 간격 (5m, 15m)
+            interval: 시간 간격 (1m, 5m, 15m)
         Returns:
             OHLCV DataFrame
         """


### PR DESCRIPTION
## Summary
- implement `OneMinStrategy` using 1 minute candles
- add optional bullish filter
- fetch 1m data in `MarketData`
- update trading bot to use new strategy
- expose new `bull_filter` flag in settings

## Testing
- `pip install pandas -q`
- `PYTHONPATH=. pytest -q` *(fails: Config and TradingState tests)*

------
https://chatgpt.com/codex/tasks/task_e_6847a825be688329babd6a5856491d20