### PR TITLE
Fix socketio for settings

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -6,9 +6,8 @@ from core.market_analyzer import MarketAnalyzer
 from core.upbit_api import UpbitAPI
 from core.telegram_notifier import TelegramNotifier
 import logging
-import socketio
 import asyncio
-from flask_socketio import SocketIO
+from app import socketio
 from config.default_settings import DEFAULT_SETTINGS  # 기본 설정 불러오기
 
 # 설정 파일 경로
@@ -458,16 +457,12 @@ def logs_page():
     """로그 페이지 렌더링"""
     return render_template('logs.html')
 
-# Socket.IO 초기화
-socketio = SocketIO()
+# Socket.IO는 app.py에서 초기화된 인스턴스를 사용합니다.
 
 def init_app(app):
-    # Blueprint 등록
+    """Blueprint 및 Socket.IO 초기화"""
     app.register_blueprint(api)
-    
-    # Socket.IO 초기화
-    socketio.init_app(app)
-    
+
     # 초기 설정 파일 생성
     if not os.path.exists(SETTINGS_FILE):
-        save_settings(DEFAULT_SETTINGS) 
+        save_settings(DEFAULT_SETTINGS)


### PR DESCRIPTION
## Summary
- use the `socketio` instance from `app.py`
- cleanup unused code in `routes.init_app`

## Testing
- `PYTHONPATH=. pytest -q` *(fails: FAILED tests/test_config_sync.py::TestConfigSync::test_config_file_persistence ...)*

------
https://chatgpt.com/codex/tasks/task_e_6847a90382e08329abc136a8cb5deab6