### PR TITLE
Modify order price setting options

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -12,8 +12,8 @@
                 "KRW-XCORE",
                 "KRW-GAS"
             ],
-            "buy_price_type": "market",
-            "sell_price_type": "market"
+            "buy_price_type": "best_bid",
+            "sell_price_type": "best_ask"
         }
     },
     "signals": {

--- a/core/upbit_api.py
+++ b/core/upbit_api.py
@@ -312,6 +312,16 @@ class UpbitAPI:
             self.logger.error(f"OHLCV 조회 실패: {str(e)}")
             return None
 
+    def get_orderbook(self, market: str):
+        """호가 정보 조회"""
+        try:
+            import pyupbit
+            orderbook = pyupbit.get_orderbook(tickers=market)
+            return orderbook[0] if orderbook else None
+        except Exception as e:
+            self.logger.error(f"호가 조회 실패: {str(e)}")
+            return None
+
     def buy_market_order(self, market: str, price: float):
         """시장가 매수"""
         if not self.upbit:

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -21,8 +21,8 @@ const recommendedSettings = {
             max_price: 500000,      // 최대 50만원
             top_volume_count: 30,    // 상위 30개 거래량
             excluded_coins: [],
-            buy_price_type: 'market',    // 매수가 설정 (market/limit/under)
-            sell_price_type: 'market'    // 매도가 설정 (market/limit/over)
+            buy_price_type: 'best_bid',    // 매수가 설정 (best_bid/best_bid+1/best_ask)
+            sell_price_type: 'best_ask'    // 매도가 설정 (best_ask/best_ask-1/best_bid)
         }
     },
     signals: {
@@ -215,11 +215,11 @@ function updateFormValues(settings) {
     setValue('trading.top_volume_count', settings.trading?.coin_selection?.top_volume_count);
 
     // 매수가 설정
-    const buyPriceType = settings.trading?.buy_price_type || 'market';
+    const buyPriceType = settings.trading?.buy_price_type || 'best_bid';
     document.querySelector(`input[name="buy_price_type"][value="${buyPriceType}"]`).checked = true;
 
     // 매도가 설정
-    const sellPriceType = settings.trading?.sell_price_type || 'market';
+    const sellPriceType = settings.trading?.sell_price_type || 'best_ask';
     document.querySelector(`input[name="sell_price_type"][value="${sellPriceType}"]`).checked = true;
 
     // 매수 지표 설정

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -396,14 +396,14 @@
                         <div class="mt-4">
                             <h6 class="mb-3">매수가 설정</h6>
                             <div class="btn-group w-100" role="group">
-                                <input type="radio" class="btn-check" name="buy_price_type" id="buy_price_market" value="market" checked>
-                                <label class="btn btn-outline-primary" for="buy_price_market">시장가</label>
+                                <input type="radio" class="btn-check" name="buy_price_type" id="buy_price_best_bid" value="best_bid" checked>
+                                <label class="btn btn-outline-primary" for="buy_price_best_bid">최고매수호가</label>
 
-                                <input type="radio" class="btn-check" name="buy_price_type" id="buy_price_limit" value="limit">
-                                <label class="btn btn-outline-primary" for="buy_price_limit">매수호가</label>
+                                <input type="radio" class="btn-check" name="buy_price_type" id="buy_price_best_bid_plus" value="best_bid+1">
+                                <label class="btn btn-outline-primary" for="buy_price_best_bid_plus">최고매수+1호가</label>
 
-                                <input type="radio" class="btn-check" name="buy_price_type" id="buy_price_under" value="under">
-                                <label class="btn btn-outline-primary" for="buy_price_under">매수가 -1호가</label>
+                                <input type="radio" class="btn-check" name="buy_price_type" id="buy_price_best_ask" value="best_ask">
+                                <label class="btn btn-outline-primary" for="buy_price_best_ask">최저매도호가</label>
                             </div>
                         </div>
                     </div>
@@ -419,14 +419,14 @@
                         <div class="mb-4">
                             <h6 class="mb-3">매도가 설정</h6>
                             <div class="btn-group w-100" role="group">
-                                <input type="radio" class="btn-check" name="sell_price_type" id="sell_price_market" value="market" checked>
-                                <label class="btn btn-outline-primary" for="sell_price_market">시장가</label>
+                                <input type="radio" class="btn-check" name="sell_price_type" id="sell_price_best_ask" value="best_ask" checked>
+                                <label class="btn btn-outline-primary" for="sell_price_best_ask">최저매도호가</label>
 
-                                <input type="radio" class="btn-check" name="sell_price_type" id="sell_price_limit" value="limit">
-                                <label class="btn btn-outline-primary" for="sell_price_limit">매도호가</label>
+                                <input type="radio" class="btn-check" name="sell_price_type" id="sell_price_best_ask_minus" value="best_ask-1">
+                                <label class="btn btn-outline-primary" for="sell_price_best_ask_minus">최고매도-1호가</label>
 
-                                <input type="radio" class="btn-check" name="sell_price_type" id="sell_price_over" value="over">
-                                <label class="btn btn-outline-primary" for="sell_price_over">매도가 +1호가</label>
+                                <input type="radio" class="btn-check" name="sell_price_type" id="sell_price_best_bid" value="best_bid">
+                                <label class="btn btn-outline-primary" for="sell_price_best_bid">최고매수호가</label>
                             </div>
                         </div>
 


### PR DESCRIPTION
## Summary
- add `get_orderbook` to `UpbitAPI`
- update `OrderManager` to support `best_bid`/`best_bid+1`/`best_ask` buy orders and `best_ask`/`best_ask-1`/`best_bid` sell orders
- adjust default price type settings in config and UI
- revise settings page radio buttons to reflect new options

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError and assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847a97f71f48329a142492ccbe80bde