### PR TITLE
Fix circular import with Flask-SocketIO

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, render_template, jsonify, request
-from flask_socketio import SocketIO, emit
+from flask_socketio import emit
+from extensions import socketio
 import logging
 from logging.handlers import RotatingFileHandler
 import json
@@ -44,7 +45,7 @@ DEFAULT_SETTINGS = {
 }
 
 app = Flask(__name__)
-socketio = SocketIO(app, cors_allowed_origins="*")
+socketio.init_app(app)
 
 # MarketAnalyzer 초기화
 try:

--- a/extensions.py
+++ b/extensions.py
@@ -1,0 +1,4 @@
+from flask_socketio import SocketIO
+
+# SocketIO instance to be shared across modules
+socketio = SocketIO(cors_allowed_origins="*")

--- a/routes.py
+++ b/routes.py
@@ -7,7 +7,7 @@ from core.upbit_api import UpbitAPI
 from core.telegram_notifier import TelegramNotifier
 import logging
 import asyncio
-from app import socketio
+from extensions import socketio
 from config.default_settings import DEFAULT_SETTINGS  # 기본 설정 불러오기
 
 # 설정 파일 경로


### PR DESCRIPTION
## Summary
- centralize SocketIO instance in `extensions.py`
- update `app.py` and `routes.py` to use the shared socketio

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6847aa5071488329be98501c5a06ade8