### PR TITLE
Add score-based 1m buy strategy

### DIFF
--- a/config/default_settings.py
+++ b/config/default_settings.py
@@ -132,7 +132,27 @@ DEFAULT_SETTINGS = {
             "signal": True
         }
     },
+    "buy_score": {
+        "strength_weight": 2,
+        "strength_threshold": 130,
+        "volume_spike_weight": 2,
+        "volume_spike_threshold": 200,
+        "orderbook_weight": 1,
+        "orderbook_threshold": 130,
+        "momentum_weight": 1,
+        "momentum_threshold": 0.3,
+        "near_high_weight": 1,
+        "near_high_threshold": -1,
+        "trend_reversal_weight": 1,
+        "williams_weight": 1,
+        "williams_enabled": True,
+        "stochastic_weight": 1,
+        "stochastic_enabled": True,
+        "macd_weight": 1,
+        "macd_enabled": True,
+        "score_threshold": 6
+    },
     "auto_settings": {
         "enabled": False
     }
-} 
+}

--- a/config/settings.json
+++ b/config/settings.json
@@ -84,5 +84,25 @@
             "daily_summary": true,
             "signal": true
         }
+    },
+    "buy_score": {
+        "strength_weight": 2,
+        "strength_threshold": 130,
+        "volume_spike_weight": 2,
+        "volume_spike_threshold": 200,
+        "orderbook_weight": 1,
+        "orderbook_threshold": 130,
+        "momentum_weight": 1,
+        "momentum_threshold": 0.3,
+        "near_high_weight": 1,
+        "near_high_threshold": -1,
+        "trend_reversal_weight": 1,
+        "williams_weight": 1,
+        "williams_enabled": true,
+        "stochastic_weight": 1,
+        "stochastic_enabled": true,
+        "macd_weight": 1,
+        "macd_enabled": true,
+        "score_threshold": 6
     }
 }

--- a/core/upbit_api.py
+++ b/core/upbit_api.py
@@ -322,6 +322,16 @@ class UpbitAPI:
             self.logger.error(f"호가 조회 실패: {str(e)}")
             return None
 
+    def get_recent_trades(self, market: str, count: int = 100):
+        """최근 체결 내역 조회"""
+        try:
+            import pyupbit
+            trades = pyupbit.get_recent_trades(market, count=count)
+            return trades
+        except Exception as e:
+            self.logger.error(f"최근 체결 조회 실패: {str(e)}")
+            return []
+
     def buy_market_order(self, market: str, price: float):
         """시장가 매수"""
         if not self.upbit:

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -93,6 +93,26 @@ const recommendedSettings = {
             daily_summary: true,
             signal: true
         }
+    },
+    buy_score: {
+        strength_weight: 2,
+        strength_threshold: 130,
+        volume_spike_weight: 2,
+        volume_spike_threshold: 200,
+        orderbook_weight: 1,
+        orderbook_threshold: 130,
+        momentum_weight: 1,
+        momentum_threshold: 0.3,
+        near_high_weight: 1,
+        near_high_threshold: -1,
+        trend_reversal_weight: 1,
+        williams_weight: 1,
+        williams_enabled: true,
+        stochastic_weight: 1,
+        stochastic_enabled: true,
+        macd_weight: 1,
+        macd_enabled: true,
+        score_threshold: 6
     }
 };
 
@@ -285,6 +305,26 @@ function updateFormValues(settings) {
     setValue('notifications.system.error', notifications.system?.error);
     setValue('notifications.system.daily_summary', notifications.system?.daily_summary);
     setValue('notifications.system.signal', notifications.system?.signal);
+
+    const score = settings.buy_score || {};
+    setValue('buy_score.strength_weight', score.strength_weight);
+    setValue('buy_score.strength_threshold', score.strength_threshold);
+    setValue('buy_score.volume_spike_weight', score.volume_spike_weight);
+    setValue('buy_score.volume_spike_threshold', score.volume_spike_threshold);
+    setValue('buy_score.orderbook_weight', score.orderbook_weight);
+    setValue('buy_score.orderbook_threshold', score.orderbook_threshold);
+    setValue('buy_score.momentum_weight', score.momentum_weight);
+    setValue('buy_score.momentum_threshold', score.momentum_threshold);
+    setValue('buy_score.near_high_weight', score.near_high_weight);
+    setValue('buy_score.near_high_threshold', score.near_high_threshold);
+    setValue('buy_score.trend_reversal_weight', score.trend_reversal_weight);
+    setValue('buy_score.williams_weight', score.williams_weight);
+    document.getElementById('buy_score.williams_enabled').value = String(score.williams_enabled);
+    setValue('buy_score.stochastic_weight', score.stochastic_weight);
+    document.getElementById('buy_score.stochastic_enabled').value = String(score.stochastic_enabled);
+    setValue('buy_score.macd_weight', score.macd_weight);
+    document.getElementById('buy_score.macd_enabled').value = String(score.macd_enabled);
+    setValue('buy_score.score_threshold', score.score_threshold);
 }
 
 // 설정 저장
@@ -369,6 +409,26 @@ function saveSettings() {
                 daily_summary: getBooleanValue('notifications.system.daily_summary'),
                 signal: getBooleanValue('notifications.system.signal')
             }
+        },
+        buy_score: {
+            strength_weight: getNumberValue('buy_score.strength_weight'),
+            strength_threshold: getNumberValue('buy_score.strength_threshold'),
+            volume_spike_weight: getNumberValue('buy_score.volume_spike_weight'),
+            volume_spike_threshold: getNumberValue('buy_score.volume_spike_threshold'),
+            orderbook_weight: getNumberValue('buy_score.orderbook_weight'),
+            orderbook_threshold: getNumberValue('buy_score.orderbook_threshold'),
+            momentum_weight: getNumberValue('buy_score.momentum_weight'),
+            momentum_threshold: getNumberValue('buy_score.momentum_threshold'),
+            near_high_weight: getNumberValue('buy_score.near_high_weight'),
+            near_high_threshold: getNumberValue('buy_score.near_high_threshold'),
+            trend_reversal_weight: getNumberValue('buy_score.trend_reversal_weight'),
+            williams_weight: getNumberValue('buy_score.williams_weight'),
+            williams_enabled: document.getElementById('buy_score.williams_enabled').value === 'true',
+            stochastic_weight: getNumberValue('buy_score.stochastic_weight'),
+            stochastic_enabled: document.getElementById('buy_score.stochastic_enabled').value === 'true',
+            macd_weight: getNumberValue('buy_score.macd_weight'),
+            macd_enabled: document.getElementById('buy_score.macd_enabled').value === 'true',
+            score_threshold: getNumberValue('buy_score.score_threshold')
         }
     };
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -307,99 +307,88 @@
                         <table class="market-table table table-bordered">
                             <thead>
                                 <tr>
-                                    <th>지표</th>
-                                    <th>상승장</th>
-                                    <th>박스장</th>
-                                    <th>하락장</th>
+                                    <th>전략 지표</th>
+                                    <th>가중치(점수)</th>
+                                    <th>Value</th>
+                                    <th>단위</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td>
-                                        진입 RSI 임계값
-                                        <small class="d-block text-muted">RSI 14가 이 값 이하일 때 진입 허용</small>
-                                    </td>
-                                    <td><input type="number" id="signals.buy_conditions.bull.rsi" value="40"></td>
-                                    <td><input type="number" id="signals.buy_conditions.range.rsi" value="35"></td>
-                                    <td><input type="number" id="signals.buy_conditions.bear.rsi" value="30"></td>
+                                    <td>체결강도</td>
+                                    <td><input type="number" id="buy_score.strength_weight" value="2"></td>
+                                    <td><input type="number" id="buy_score.strength_threshold" value="130"></td>
+                                    <td>%</td>
                                 </tr>
                                 <tr>
-                                    <td>
-                                        볼린저 σ
-                                        <small class="d-block text-muted">BB(20, σ) 하단선 이탈 감도</small>
-                                    </td>
-                                    <td><input type="number" step="0.1" id="signals.buy_conditions.bull.sigma" value="1.8"></td>
-                                    <td><input type="number" step="0.1" id="signals.buy_conditions.range.sigma" value="2.0"></td>
-                                    <td><input type="number" step="0.1" id="signals.buy_conditions.bear.sigma" value="2.2"></td>
+                                    <td>실시간 거래량 급증</td>
+                                    <td><input type="number" id="buy_score.volume_spike_weight" value="2"></td>
+                                    <td><input type="number" id="buy_score.volume_spike_threshold" value="200"></td>
+                                    <td>%</td>
                                 </tr>
                                 <tr>
-                                    <td>
-                                        거래량 배수(전봉)
-                                        <small class="d-block text-muted">current_vol ≥ prev_vol × 배수</small>
-                                    </td>
-                                    <td><input type="number" step="0.1" id="signals.buy_conditions.bull.vol_prev" value="1.5"></td>
-                                    <td><input type="number" step="0.1" id="signals.buy_conditions.range.vol_prev" value="2.0"></td>
-                                    <td><input type="number" step="0.1" id="signals.buy_conditions.bear.vol_prev" value="2.5"></td>
+                                    <td>호가 잔량 불균형</td>
+                                    <td><input type="number" id="buy_score.orderbook_weight" value="1"></td>
+                                    <td><input type="number" id="buy_score.orderbook_threshold" value="130"></td>
+                                    <td>%</td>
                                 </tr>
                                 <tr>
-                                    <td>
-                                        거래량 배수(5-MA)
-                                        <small class="d-block text-muted">current_vol ≥ vol_MA5 × 배수</small>
-                                    </td>
-                                    <td><input type="number" step="0.1" id="signals.buy_conditions.bull.vol_ma" value="1.2"></td>
-                                    <td><input type="number" step="0.1" id="signals.buy_conditions.range.vol_ma" value="1.5"></td>
-                                    <td><input type="number" step="0.1" id="signals.buy_conditions.bear.vol_ma" value="1.8"></td>
+                                    <td>단기 등락률</td>
+                                    <td><input type="number" id="buy_score.momentum_weight" value="1"></td>
+                                    <td><input type="number" step="0.1" id="buy_score.momentum_threshold" value="0.3"></td>
+                                    <td>%</td>
                                 </tr>
                                 <tr>
+                                    <td>전고점 근접 여부</td>
+                                    <td><input type="number" id="buy_score.near_high_weight" value="1"></td>
+                                    <td><input type="number" id="buy_score.near_high_threshold" value="-1"></td>
+                                    <td>%</td>
+                                </tr>
+                                <tr>
+                                    <td>추세 전환 징후</td>
+                                    <td><input type="number" id="buy_score.trend_reversal_weight" value="1"></td>
+                                    <td>하락 &gt; 상승</td>
+                                    <td>-</td>
+                                </tr>
+                                <tr>
+                                    <td>Williams %R</td>
+                                    <td><input type="number" id="buy_score.williams_weight" value="1"></td>
                                     <td>
-                                        골든크로스 기울기
-                                        <small class="d-block text-muted">SMA5 slope ≥ min_slope (비율)</small>
+                                        <select id="buy_score.williams_enabled" class="form-select form-select-sm">
+                                            <option value="true">ON</option>
+                                            <option value="false">OFF</option>
+                                        </select>
                                     </td>
-                                    <td><input type="number" step="0.01" id="signals.buy_conditions.bull.slope" value="0.12"></td>
-                                    <td><input type="number" step="0.01" id="signals.buy_conditions.range.slope" value="0.10"></td>
-                                    <td><input type="number" step="0.01" id="signals.buy_conditions.bear.slope" value="0.08"></td>
+                                    <td>-</td>
+                                </tr>
+                                <tr>
+                                    <td>Stochastic</td>
+                                    <td><input type="number" id="buy_score.stochastic_weight" value="1"></td>
+                                    <td>
+                                        <select id="buy_score.stochastic_enabled" class="form-select form-select-sm">
+                                            <option value="true">ON</option>
+                                            <option value="false">OFF</option>
+                                        </select>
+                                    </td>
+                                    <td>-</td>
+                                </tr>
+                                <tr>
+                                    <td>MACD</td>
+                                    <td><input type="number" id="buy_score.macd_weight" value="1"></td>
+                                    <td>
+                                        <select id="buy_score.macd_enabled" class="form-select form-select-sm">
+                                            <option value="true">ON</option>
+                                            <option value="false">OFF</option>
+                                        </select>
+                                    </td>
+                                    <td>-</td>
                                 </tr>
                             </tbody>
                         </table>
 
-                        <!-- 매수 조건 토글 -->
-                        <div class="mt-4">
-                            <h6 class="mb-3">매수 조건</h6>
-                            <div class="mb-2">
-                                <label class="toggle-switch">
-                                    <input type="checkbox" id="signals.buy_conditions.enabled.trend_filter">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <label class="ms-2">15분 추세 필터</label>
-                            </div>
-                            <div class="mb-2">
-                                <label class="toggle-switch">
-                                    <input type="checkbox" id="signals.buy_conditions.enabled.golden_cross">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <label class="ms-2">SMA 5/20 골든크로스</label>
-                            </div>
-                            <div class="mb-2">
-                                <label class="toggle-switch">
-                                    <input type="checkbox" id="signals.buy_conditions.enabled.rsi">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <label class="ms-2">RSI 과매도 2캔들 연속</label>
-                            </div>
-                            <div class="mb-2">
-                                <label class="toggle-switch">
-                                    <input type="checkbox" id="signals.buy_conditions.enabled.bollinger">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <label class="ms-2">볼린저 밴드 하단선 이탈</label>
-                            </div>
-                            <div class="mb-2">
-                                <label class="toggle-switch">
-                                    <input type="checkbox" id="signals.buy_conditions.enabled.volume_surge">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <label class="ms-2">거래량 급증</label>
-                            </div>
+                        <div class="mt-3" style="max-width:200px;">
+                            <label class="form-label">매수 허용 점수</label>
+                            <input type="number" id="buy_score.score_threshold" value="6" class="form-control">
                         </div>
 
                         <!-- 매수가 선택 -->

--- a/trading/bot/trading_bot.py
+++ b/trading/bot/trading_bot.py
@@ -24,7 +24,7 @@ class TradingBot:
         self.market_data = MarketData(self.exchange, settings)
         
         # 전략 초기화
-        self.strategy = OneMinStrategy(settings)
+        self.strategy = OneMinStrategy(settings, self.exchange)
         
         # 실행 상태
         self.is_running = False
@@ -123,7 +123,7 @@ class TradingBot:
                     continue
                     
                 # 매수 신호 확인
-                if self.strategy.check_buy_signal(df_1m, df_15m):
+                if self.strategy.check_buy_signal(symbol, df_1m, df_15m):
                     # 시장가 매수 실행
                     order = self.exchange.buy_market_order(symbol, investment_amount)
                     if order:

--- a/trading/strategies/one_min_strategy.py
+++ b/trading/strategies/one_min_strategy.py
@@ -5,78 +5,116 @@ from ..indicators.technical import (
     calculate_ema, calculate_sma, calculate_bollinger_bands,
     calculate_rsi, calculate_slope, calculate_volume_conditions
 )
+from core.upbit_api import UpbitAPI
 from ..utils.logger import TradingLogger
 
 class OneMinStrategy:
-    def __init__(self, settings: Dict):
+    def __init__(self, settings: Dict, exchange: UpbitAPI):
         """
         1분봉 매매 전략 클래스
         Args:
             settings: 설정값 딕셔너리
         """
         self.settings = settings
+        self.exchange = exchange
         self.logger = TradingLogger("OneMinStrategy")
         self.positions: Dict[str, Dict] = {}  # 보유 포지션 정보
         
-    def check_buy_signal(self, df_1m: pd.DataFrame, df_15m: pd.DataFrame) -> bool:
-        """매수 신호 확인"""
-        if len(df_1m) < 20 or len(df_15m) < 50:  # 최소 데이터 확인
+    def check_buy_signal(self, symbol: str, df_1m: pd.DataFrame, df_15m: pd.DataFrame) -> bool:
+        """점수 기반 매수 신호 확인"""
+        if len(df_1m) < 20 or len(df_15m) < 20:
             return False
-            
-        # 15분봉 추세 필터
-        if self.settings['signals']['buy_conditions']['enabled']['trend_filter']:
-            ema50_15m = calculate_ema(df_15m['close'], 50)
-            current_price = df_15m['close'].iloc[-1]
-            prev_ema = ema50_15m.iloc[-2]
-            current_ema = ema50_15m.iloc[-1]
-            
-            if not (current_price > current_ema and current_ema > prev_ema):
-                return False
-        
-        buy_conf = self.settings['signals']['buy_conditions']
 
-        # 상승장 필터가 활성화된 경우 시장 상황 확인
-        if buy_conf['enabled'].get('bull_filter', False):
-            if self._determine_market_condition(df_15m) != 'bull':
-                return False
+        score = self._calculate_score(symbol, df_1m)
+        threshold = self.settings.get('buy_score', {}).get('score_threshold', 0)
+        if score >= threshold:
+            self.logger.info(f"{symbol} 매수 점수 {score} / {threshold}")
+            return True
+        return False
 
-        # 단일 조건값 구조와 호환을 위해 분기 처리
-        if 'rsi' in buy_conf:
-            conditions = buy_conf
-        else:
-            conditions = buy_conf.get('bull', {})
-        
-        # 1. 골든크로스 + 기울기
-        if self.settings['signals']['buy_conditions']['enabled']['golden_cross']:
-            sma5 = calculate_sma(df_1m['close'], 5)
-            sma20 = calculate_sma(df_1m['close'], 20)
-            
-            prev_cross = sma5.iloc[-2] <= sma20.iloc[-2]
-            current_cross = sma5.iloc[-1] > sma20.iloc[-1]
-            slope = calculate_slope(sma5)
-            
-            if not (prev_cross and current_cross and slope >= conditions['slope']):
-                return False
-        
-        # 2. RSI 과매도
-        if self.settings['signals']['buy_conditions']['enabled']['rsi']:
-            rsi = calculate_rsi(df_1m['close'], 14)
-            if not (rsi.iloc[-1] <= conditions['rsi'] and rsi.iloc[-2] <= conditions['rsi']):
-                return False
-        
-        # 3. 볼린저 밴드 하단 이탈
-        if self.settings['signals']['buy_conditions']['enabled']['bollinger']:
-            _, _, lower = calculate_bollinger_bands(df_1m['close'], 20, conditions['sigma'])
-            if not (df_1m['close'].iloc[-1] < lower.iloc[-1]):
-                return False
-        
-        # 4. 거래량 급증
-        if self.settings['signals']['buy_conditions']['enabled']['volume_surge']:
-            prev_vol, ma_vol = calculate_volume_conditions(df_1m['volume'])
-            if not (prev_vol and ma_vol):
-                return False
-        
-        return True
+    def _calculate_score(self, symbol: str, df_1m: pd.DataFrame) -> float:
+        conf = self.settings.get('buy_score', {})
+        score = 0
+
+        # 1. 체결강도
+        if conf.get('strength_weight', 0) > 0:
+            trades = self.exchange.get_recent_trades(symbol, count=100)
+            if trades:
+                buy_vol = sum(t['trade_volume'] for t in trades if t['ask_bid'] == 'BID')
+                sell_vol = sum(t['trade_volume'] for t in trades if t['ask_bid'] == 'ASK')
+                strength = (buy_vol / sell_vol * 100) if sell_vol else 0
+                if strength >= conf.get('strength_threshold', 130):
+                    score += conf['strength_weight']
+
+        # 2. 실시간 거래량 급증
+        if conf.get('volume_spike_weight', 0) > 0 and len(df_1m) > 5:
+            recent_vol = df_1m['volume'].iloc[-1]
+            avg_vol = df_1m['volume'].iloc[-6:-1].mean()
+            if avg_vol and recent_vol >= avg_vol * (conf.get('volume_spike_threshold', 200) / 100):
+                score += conf['volume_spike_weight']
+
+        # 3. 호가 잔량 불균형
+        if conf.get('orderbook_weight', 0) > 0:
+            ob = self.exchange.get_orderbook(symbol)
+            if ob:
+                bid = float(ob.get('total_bid_size', 0))
+                ask = float(ob.get('total_ask_size', 0))
+                if ask and (bid / ask * 100) >= conf.get('orderbook_threshold', 130):
+                    score += conf['orderbook_weight']
+
+        # 4. 단기 등락률
+        if conf.get('momentum_weight', 0) > 0 and len(df_1m) > 4:
+            change = (df_1m['close'].iloc[-1] / df_1m['close'].iloc[-4] - 1) * 100
+            if change >= conf.get('momentum_threshold', 0.3):
+                score += conf['momentum_weight']
+            elif change <= -conf.get('momentum_threshold', 0.3):
+                return 0
+
+        # 5. 전고점 근접 여부
+        if conf.get('near_high_weight', 0) > 0:
+            day = self.exchange.get_ohlcv(symbol, 'day', 2)
+            if day is not None and len(day) >= 2:
+                prev_high = max(day['high'].iloc[-2], day['high'].iloc[-1])
+                price = df_1m['close'].iloc[-1]
+                if prev_high and abs(price - prev_high) / prev_high <= abs(conf.get('near_high_threshold', -1)) / 100:
+                    score += conf['near_high_weight']
+
+        # 6. 추세 전환 징후
+        if conf.get('trend_reversal_weight', 0) > 0 and len(df_1m) > 16:
+            past_15 = df_1m['close'].iloc[-16]
+            past_5 = df_1m['close'].iloc[-6]
+            current = df_1m['close'].iloc[-1]
+            if past_15 > current and current > past_5:
+                score += conf['trend_reversal_weight']
+
+        # 7. Williams %R
+        if conf.get('williams_weight', 0) > 0 and conf.get('williams_enabled', True) and len(df_1m) >= 14:
+            hh = df_1m['high'].iloc[-14:].max()
+            ll = df_1m['low'].iloc[-14:].min()
+            if hh != ll:
+                wr = (hh - df_1m['close'].iloc[-1]) / (hh - ll) * -100
+                if wr <= -80:
+                    score += conf['williams_weight']
+
+        # 8. Stochastic
+        if conf.get('stochastic_weight', 0) > 0 and conf.get('stochastic_enabled', True) and len(df_1m) >= 14:
+            lowest = df_1m['low'].rolling(14).min()
+            highest = df_1m['high'].rolling(14).max()
+            k = (df_1m['close'] - lowest) / (highest - lowest) * 100
+            d = k.rolling(3).mean()
+            if k.iloc[-1] < 20 and d.iloc[-1] < 20:
+                score += conf['stochastic_weight']
+
+        # 9. MACD
+        if conf.get('macd_weight', 0) > 0 and conf.get('macd_enabled', True):
+            ema12 = df_1m['close'].ewm(span=12).mean()
+            ema26 = df_1m['close'].ewm(span=26).mean()
+            macd = ema12 - ema26
+            signal = macd.ewm(span=9).mean()
+            if macd.iloc[-1] > signal.iloc[-1] and macd.iloc[-2] <= signal.iloc[-2]:
+                score += conf['macd_weight']
+
+        return score
     
     def check_sell_signal(self, symbol: str, df_1m: pd.DataFrame) -> bool:
         """매도 신호 확인"""


### PR DESCRIPTION
## Summary
- implement point system buy strategy in `OneMinStrategy`
- provide recent trades API helper
- update trading bot to pass exchange into strategy
- expose buy score settings in default config and UI
- revise settings.js to load/save new values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError & assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847c6736aa48329bf89ca8297d80ee9