### PR TITLE
Fix current_app import for settings API

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -1,4 +1,4 @@
-from flask import jsonify, request, Blueprint, render_template
+from flask import jsonify, request, Blueprint, render_template, current_app
 import json
 import os
 from datetime import datetime


### PR DESCRIPTION
## Summary
- fix missing import for `current_app` in `routes.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6847c7a7ec1c83299a1067cb23f1369a