### PR TITLE
Fix default buy score settings on web page

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -214,13 +214,26 @@ function markSettingsAsChanged() {
 }
 
 // 설정 로드
+function mergeDeep(target, source) {
+    for (const key in source) {
+        if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+            if (!target[key]) target[key] = {};
+            mergeDeep(target[key], source[key]);
+        } else {
+            target[key] = source[key];
+        }
+    }
+    return target;
+}
+
 function loadSettings() {
     fetch('/api/settings')
         .then(response => response.json())
-        .then(settings => {
-            currentSettings = settings;
-            updateFormValues(settings);
-            updateExcludedCoinsList(settings.trading?.coin_selection?.excluded_coins || []);
+        .then(data => {
+            const settings = data.data || data;
+            currentSettings = mergeDeep(JSON.parse(JSON.stringify(recommendedSettings)), settings);
+            updateFormValues(currentSettings);
+            updateExcludedCoinsList(currentSettings.trading?.coin_selection?.excluded_coins || []);
         })
         .catch(error => {
             console.error('설정을 불러오는 중 오류가 발생했습니다:', error);


### PR DESCRIPTION
## Summary
- ensure settings page falls back to defaults when fields missing
- merge recommended defaults with loaded settings
- parse `/api/settings` response correctly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6847cd38450083299461ef0a723407f6