### PR TITLE
Support default buy_score configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -99,6 +99,26 @@
             "signal": false
         }
     },
+    "buy_score": {
+        "strength_weight": 2,
+        "strength_threshold": 130,
+        "volume_spike_weight": 2,
+        "volume_spike_threshold": 200,
+        "orderbook_weight": 1,
+        "orderbook_threshold": 130,
+        "momentum_weight": 1,
+        "momentum_threshold": 0.3,
+        "near_high_weight": 1,
+        "near_high_threshold": -1,
+        "trend_reversal_weight": 1,
+        "williams_weight": 1,
+        "williams_enabled": true,
+        "stochastic_weight": 1,
+        "stochastic_enabled": true,
+        "macd_weight": 1,
+        "macd_enabled": true,
+        "score_threshold": 6
+    },
     "auto_settings": {
         "enabled": false
     },

--- a/core/config.py
+++ b/core/config.py
@@ -207,6 +207,26 @@ class Config:
                 "signal": True
             }
         },
+        "buy_score": {
+            "strength_weight": 2,
+            "strength_threshold": 130,
+            "volume_spike_weight": 2,
+            "volume_spike_threshold": 200,
+            "orderbook_weight": 1,
+            "orderbook_threshold": 130,
+            "momentum_weight": 1,
+            "momentum_threshold": 0.3,
+            "near_high_weight": 1,
+            "near_high_threshold": -1,
+            "trend_reversal_weight": 1,
+            "williams_weight": 1,
+            "williams_enabled": True,
+            "stochastic_weight": 1,
+            "stochastic_enabled": True,
+            "macd_weight": 1,
+            "macd_enabled": True,
+            "score_threshold": 6
+        },
         "auto_settings": {
             "enabled": False,
             "market_conditions": {

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -215,6 +215,26 @@ class ConfigManager:
                     "signal": True
                 }
             },
+            "buy_score": {
+                "strength_weight": 2,
+                "strength_threshold": 130,
+                "volume_spike_weight": 2,
+                "volume_spike_threshold": 200,
+                "orderbook_weight": 1,
+                "orderbook_threshold": 130,
+                "momentum_weight": 1,
+                "momentum_threshold": 0.3,
+                "near_high_weight": 1,
+                "near_high_threshold": -1,
+                "trend_reversal_weight": 1,
+                "williams_weight": 1,
+                "williams_enabled": True,
+                "stochastic_weight": 1,
+                "stochastic_enabled": True,
+                "macd_weight": 1,
+                "macd_enabled": True,
+                "score_threshold": 6
+            },
             "auto_settings": {
                 "enabled": False
             }
@@ -259,7 +279,7 @@ class ConfigManager:
             nested["trading"] = config["trading"]
 
         # 나머지 중첩 구조는 그대로 유지
-        for key in ["signals", "notifications", "auto_settings", "version"]:
+        for key in ["signals", "notifications", "auto_settings", "version", "buy_score"]:
             if key in config:
                 nested[key] = config[key]
 


### PR DESCRIPTION
## Summary
- add default buy_score to configuration classes
- persist buy_score in sample config
- include new section during config parsing

## Testing
- `pip install -q flask flask-socketio python-socketio python-engineio requests numpy pandas scipy websocket-client python-dotenv eventlet PyJWT ta websockets python-telegram-bot`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError, failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6847cd87e8988329957a416fbc75699c