### PR TITLE
Update sell strategy with fixed TP order

### DIFF
--- a/config/sell_settings.json
+++ b/config/sell_settings.json
@@ -1,0 +1,4 @@
+{
+  "TP_PCT": 0.18,
+  "MINIMUM_TICKS": 2
+}


### PR DESCRIPTION
## Summary
- add `sell_settings.json` for TP settings
- simplify `OneMinStrategy` to remove old sell checks and store sell order info
- overhaul `TradingBot` to place limit sell orders immediately after buy and monitor order status

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6847cf06ed8483299c1ea62fd7d8e63f