### PR TITLE
Fix connect handler signature

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,7 +201,7 @@ def monitor_market():
 
 # Socket.IO 이벤트 핸들러
 @socketio.on('connect')
-def handle_connect():
+def handle_connect(auth=None):
     """소켓 연결 이벤트 핸들러"""
     try:
         logger.debug('Client connected')

--- a/web/app.py
+++ b/web/app.py
@@ -475,7 +475,7 @@ def monitor_market():
             socketio.sleep(5)  # 오류 발생 시 5초 대기
 
 @socketio.on('connect')
-def handle_connect():
+def handle_connect(auth=None):
     """소켓 연결 이벤트 핸들러"""
     try:
         logger.info('Client connected')


### PR DESCRIPTION
## Summary
- update Socket.IO connect handler functions to accept optional auth parameter

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6847d3959ee88329867bc45cbe2881d5