### PR TITLE
Update sell order logic

### DIFF
--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -79,6 +79,7 @@ class MarketAnalyzer:
         """초기화"""
         self.config_path = config_path
         self.buy_settings_path = str(Path(__file__).parent.parent / 'config' / 'buy_settings.json')
+        self.sell_settings_path = str(Path(__file__).parent.parent / 'config' / 'sell_settings.json')
         self.server_url = 'https://api.upbit.com'
         self.request_timeout = 10
         self.cache_duration = 900
@@ -1638,6 +1639,16 @@ class MarketAnalyzer:
             logger.error(f"매수 설정 로드 실패: {e}")
         return {}
 
+    def get_sell_settings(self) -> Dict:
+        """매도 주문 설정 조회"""
+        try:
+            if os.path.exists(self.sell_settings_path):
+                with open(self.sell_settings_path, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+        except Exception as e:
+            logger.error(f"매도 설정 로드 실패: {e}")
+        return {}
+
     def save_buy_settings(self, settings: Dict) -> bool:
         """매수 주문 설정 저장"""
         try:
@@ -1648,6 +1659,23 @@ class MarketAnalyzer:
             return True
         except Exception as e:
             logger.error(f"매수 설정 저장 실패: {e}")
+            if os.path.exists(tmp):
+                try:
+                    os.remove(tmp)
+                except Exception:
+                    pass
+            return False
+
+    def save_sell_settings(self, settings: Dict) -> bool:
+        """매도 주문 설정 저장"""
+        try:
+            tmp = self.sell_settings_path + '.tmp'
+            with open(tmp, 'w', encoding='utf-8') as f:
+                json.dump(settings, f, indent=4, ensure_ascii=False)
+            os.replace(tmp, self.sell_settings_path)
+            return True
+        except Exception as e:
+            logger.error(f"매도 설정 저장 실패: {e}")
             if os.path.exists(tmp):
                 try:
                     os.remove(tmp)

--- a/core/order_manager.py
+++ b/core/order_manager.py
@@ -258,6 +258,27 @@ class OrderManager:
             logger.error(f"{market}: 지정가 매수 처리 중 오류 발생 - {str(e)}")
             return False, None
 
+    def place_limit_sell(self, market: str, volume: float, price: float) -> Tuple[bool, Optional[Dict]]:
+        """지정가 매도 주문"""
+        try:
+            order = self.api.place_order(
+                market=market,
+                side='ask',
+                volume=volume,
+                price=price,
+                ord_type='limit'
+            )
+            if not order:
+                logger.error(f"{market}: 매도 주문 실패")
+                return False, None
+            success, final_order = self._wait_for_order(order['uuid'], self.order_timeout)
+            if not success:
+                self.api.cancel_order(order['uuid'])
+            return success, final_order
+        except Exception as e:
+            logger.error(f"{market}: 매도 주문 처리 중 오류 발생 - {str(e)}")
+            return False, None
+
     def buy_with_settings(self, market: str, settings: Dict) -> Tuple[bool, Optional[Dict]]:
         """설정 기반 매수 진행"""
         mapping = {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -462,127 +462,13 @@
                         <h5 class="card-title mb-0">매도 조건 설정</h5>
                     </div>
                     <div class="card-body">
-                        <!-- 매도가 설정 -->
-                        <div class="mb-4">
-                            <h6 class="mb-3">매도가 설정</h6>
-                            <div class="btn-group w-100" role="group">
-                                <input type="radio" class="btn-check" name="sell_price_type" id="sell_price_best_ask" value="best_ask" checked>
-                                <label class="btn btn-outline-primary" for="sell_price_best_ask">최저매도호가</label>
-
-                                <input type="radio" class="btn-check" name="sell_price_type" id="sell_price_best_ask_minus" value="best_ask-1">
-                                <label class="btn btn-outline-primary" for="sell_price_best_ask_minus">최고매도-1호가</label>
-
-                                <input type="radio" class="btn-check" name="sell_price_type" id="sell_price_best_bid" value="best_bid">
-                                <label class="btn btn-outline-primary" for="sell_price_best_bid">최고매수호가</label>
-                            </div>
-                        </div>
-
-                        <!-- 손절매 설정 -->
-                        <div class="mb-4">
-                            <div class="d-flex align-items-center mb-2">
-                                <label class="toggle-switch mb-0">
-                                    <input type="checkbox" id="signals.sell_conditions.stop_loss.enabled">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <label class="ms-2 mb-0">손절매(Stop Loss) 로직</label>
-                            </div>
-                            <div class="row g-2">
-                                <div class="col-6">
-                                    <div class="input-group">
-                                        <span class="input-group-text">고정 손절</span>
-                                        <input type="number" step="0.1" class="form-control" id="signals.sell_conditions.stop_loss.threshold" value="-2.5">
-                                        <span class="input-group-text">%</span>
-                                    </div>
-                                </div>
-                                <div class="col-6">
-                                    <div class="input-group">
-                                        <span class="input-group-text">추적 손절</span>
-                                        <input type="number" step="0.1" class="form-control" id="signals.sell_conditions.stop_loss.trailing_stop" value="0.5">
-                                        <span class="input-group-text">%</span>
-                                    </div>
-                                </div>
-                            </div>
-                            <small class="text-muted d-block mt-1">
-                                • 고정 손절: 진입가 대비 설정값 도달 시 즉시 청산<br>
-                                • 추적 손절: 최고가 대비 설정값 이상 하락 시 청산
-                            </small>
-                        </div>
-
-                        <!-- 익절 설정 -->
-                        <div class="mb-4">
-                            <div class="d-flex align-items-center mb-2">
-                                <label class="toggle-switch mb-0">
-                                    <input type="checkbox" id="signals.sell_conditions.take_profit.enabled">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <label class="ms-2 mb-0">익절(Take Profit) 로직</label>
-                            </div>
-                            <div class="row g-2">
-                                <div class="col-6">
-                                    <div class="input-group">
-                                        <span class="input-group-text">목표 수익</span>
-                                        <input type="number" step="0.1" class="form-control" id="signals.sell_conditions.take_profit.threshold" value="2.0">
-                                        <span class="input-group-text">%</span>
-                                    </div>
-                                </div>
-                                <div class="col-6">
-                                    <div class="input-group">
-                                        <span class="input-group-text">추적 익절</span>
-                                        <input type="number" step="0.1" class="form-control" id="signals.sell_conditions.take_profit.trailing_profit" value="1.0">
-                                        <span class="input-group-text">%</span>
-                                    </div>
-                                </div>
-                            </div>
-                            <small class="text-muted d-block mt-1">
-                                • 목표 수익: 진입가 대비 설정값 도달 시 익절<br>
-                                • 추적 익절: 최고가 대비 설정값 이상 하락 시 수익 보호 청산
-                            </small>
-                        </div>
-
-                        <!-- 기타 매도 조건 -->
                         <div class="mb-3">
-                            <div class="d-flex align-items-center mb-2">
-                                <label class="toggle-switch mb-0">
-                                    <input type="checkbox" id="signals.sell_conditions.dead_cross.enabled">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <label class="ms-2 mb-0">데드크로스 조건</label>
-                            </div>
-                            <small class="text-muted d-block ms-5">
-                                SMA 5/20 하향 교차 & 단기선 기울기 ≤ -0.1
-                            </small>
+                            <label class="form-label" for="sell_settings.TP_PCT">목표 수익률(%)</label>
+                            <input type="number" step="0.01" class="form-control" id="sell_settings.TP_PCT" value="0.18">
                         </div>
-
                         <div class="mb-3">
-                            <div class="d-flex align-items-center mb-2">
-                                <label class="toggle-switch mb-0">
-                                    <input type="checkbox" id="signals.sell_conditions.rsi.enabled">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <label class="ms-2 mb-0">RSI 과매수 조건</label>
-                            </div>
-                            <div class="ms-5">
-                                <div class="input-group" style="width: 200px;">
-                                    <span class="input-group-text">RSI ≥</span>
-                                    <input type="number" class="form-control" id="signals.sell_conditions.rsi.threshold" value="60">
-                                </div>
-                                <small class="text-muted d-block mt-1">
-                                    2캔들 연속 조건 충족 시 청산
-                                </small>
-                            </div>
-                        </div>
-
-                        <div class="mb-3">
-                            <div class="d-flex align-items-center">
-                                <label class="toggle-switch mb-0">
-                                    <input type="checkbox" id="signals.sell_conditions.bollinger.enabled">
-                                    <span class="toggle-slider"></span>
-                                </label>
-                                <label class="ms-2 mb-0">볼린저 밴드 상단 돌파</label>
-                            </div>
-                            <small class="text-muted d-block ms-5">
-                                BB(20, 2.0) 상단선 상향 돌파 시 즉시 청산
-                            </small>
+                            <label class="form-label" for="sell_settings.MINIMUM_TICKS">최소 확보 틱수</label>
+                            <input type="number" class="form-control" id="sell_settings.MINIMUM_TICKS" value="2">
                         </div>
                     </div>
                 </div>

--- a/web/app.py
+++ b/web/app.py
@@ -377,6 +377,32 @@ def save_buy_settings():
         logger.error(f"매수 설정 저장 오류: {str(e)}")
         return jsonify({'success': False, 'error': str(e)}), 500
 
+
+@app.route('/api/sell_settings', methods=['GET'])
+def get_sell_settings():
+    """매도 주문 설정 조회"""
+    try:
+        settings = market_analyzer.get_sell_settings()
+        return jsonify({'success': True, 'data': settings})
+    except Exception as e:
+        logger.error(f"매도 설정 조회 오류: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
+
+@app.route('/api/sell_settings', methods=['POST'])
+def save_sell_settings():
+    """매도 주문 설정 저장"""
+    try:
+        settings = request.json
+        if not settings:
+            return jsonify({'success': False, 'error': '데이터가 비어있습니다.'}), 400
+        if market_analyzer.save_sell_settings(settings):
+            return jsonify({'success': True})
+        return jsonify({'success': False, 'error': '매도 설정 저장 실패'}), 500
+    except Exception as e:
+        logger.error(f"매도 설정 저장 오류: {str(e)}")
+        return jsonify({'success': False, 'error': str(e)}), 500
+
 @app.route('/api/holdings', methods=['GET'])
 def get_holdings():
     """현재 보유 중인 코인 정보 조회"""


### PR DESCRIPTION
## Summary
- load and save sell settings from `config/sell_settings.json`
- implement limit sell placement based on new TP_PCT logic
- expose `/api/sell_settings` endpoints
- update trading bot to place limit sell immediately after buy
- simplify web sell settings UI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'core')*

------
https://chatgpt.com/codex/tasks/task_e_6847d3868cac8329ba34775e5aaa4902