### PR TITLE
Remove obsolete buy price setting

### DIFF
--- a/config/settings.json
+++ b/config/settings.json
@@ -14,7 +14,6 @@
                 "KRW-XCORE",
                 "KRW-GAS"
             ],
-            "buy_price_type": "best_bid",
             "sell_price_type": "best_ask"
         }
     },

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -23,8 +23,7 @@ const recommendedSettings = {
             min_volume_24h: 1400000000,
             min_volume_1h: 100000000,
             min_tick_ratio: 0.04,
-            excluded_coins: [],
-            buy_price_type: 'best_bid'    // 매수가 설정 (best_bid/best_bid+1/best_ask)
+            excluded_coins: []
         }
     },
     signals: {
@@ -123,12 +122,6 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    // 매수가 설정 변경 이벤트
-    document.querySelectorAll('input[name="buy_price_type"]').forEach(radio => {
-        radio.addEventListener('change', () => {
-            markSettingsAsChanged();
-        });
-    });
 });
 
 // 제외 코인 추가
@@ -230,10 +223,6 @@ function updateFormValues(settings) {
     setValue('trading.min_volume_24h', settings.trading?.coin_selection?.min_volume_24h);
     setValue('trading.min_volume_1h', settings.trading?.coin_selection?.min_volume_1h);
     setValue('trading.min_tick_ratio', settings.trading?.coin_selection?.min_tick_ratio);
-
-    // 매수가 설정
-    const buyPriceType = settings.trading?.buy_price_type || 'best_bid';
-    document.querySelector(`input[name="buy_price_type"][value="${buyPriceType}"]`).checked = true;
 
     // 매수 지표 설정
     const buyConditions = settings.signals?.buy_conditions || {};
@@ -358,8 +347,7 @@ function saveSettings() {
                 min_volume_24h: getNumberValue('trading.min_volume_24h'),
                 min_volume_1h: getNumberValue('trading.min_volume_1h'),
                 min_tick_ratio: getNumberValue('trading.min_tick_ratio'),
-                excluded_coins: excludedCoins,
-                buy_price_type: document.querySelector('input[name="buy_price_type"]:checked').value
+                excluded_coins: excludedCoins
             }
         },
         signals: {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -404,20 +404,6 @@
                             <input type="number" id="buy_score.score_threshold" value="6" class="form-control">
                         </div>
 
-                        <!-- 매수가 선택 -->
-                        <div class="mt-4">
-                            <h6 class="mb-3">매수가 설정</h6>
-                            <div class="btn-group w-100" role="group">
-                                <input type="radio" class="btn-check" name="buy_price_type" id="buy_price_best_bid" value="best_bid" checked>
-                                <label class="btn btn-outline-primary" for="buy_price_best_bid">최고매수호가</label>
-
-                                <input type="radio" class="btn-check" name="buy_price_type" id="buy_price_best_bid_plus" value="best_bid+1">
-                                <label class="btn btn-outline-primary" for="buy_price_best_bid_plus">최고매수+1호가</label>
-
-                                <input type="radio" class="btn-check" name="buy_price_type" id="buy_price_best_ask" value="best_ask">
-                                <label class="btn btn-outline-primary" for="buy_price_best_ask">최저매도호가</label>
-                            </div>
-                        </div>
                         <div class="mt-4">
                             <h6 class="mb-3">매수 주문 설정</h6>
                             <div class="row g-2">


### PR DESCRIPTION
## Summary
- delete buy price type options from UI and JS logic
- drop `buy_price_type` from default settings

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6847d9f02360832998d05e13d68a8816