### PR TITLE
Implement prepare_dataframe helper

### DIFF
--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -1289,6 +1289,29 @@ class MarketAnalyzer:
             logger.error(f"캔들 데이터 조회 중 오류: {str(e)}")
             return []
 
+    def prepare_dataframe(self, candles: List[Dict]) -> pd.DataFrame:
+        """캔들 데이터를 분석용 DataFrame으로 변환"""
+        try:
+            df = pd.DataFrame(candles)
+            rename_map = {
+                'opening_price': 'open',
+                'high_price': 'high',
+                'low_price': 'low',
+                'trade_price': 'close',
+                'candle_acc_trade_volume': 'volume'
+            }
+            df = df.rename(columns=rename_map)
+
+            numeric_cols = ['open', 'high', 'low', 'close', 'volume']
+            for col in numeric_cols:
+                if col in df.columns:
+                    df[col] = pd.to_numeric(df[col], errors='coerce')
+
+            return df
+        except Exception as e:
+            logger.error(f"데이터프레임 변환 오류: {str(e)}")
+            return pd.DataFrame()
+
     def calculate_moving_average(self, candles: List[Dict], period: int = 20) -> Optional[List[float]]:
         """이동평균선 계산"""
         try:

--- a/tests/test_prepare_dataframe.py
+++ b/tests/test_prepare_dataframe.py
@@ -1,0 +1,32 @@
+import unittest
+from core.market_analyzer import MarketAnalyzer
+
+class TestPrepareDataFrame(unittest.TestCase):
+    def setUp(self):
+        self.analyzer = MarketAnalyzer.__new__(MarketAnalyzer)
+
+    def test_prepare_dataframe(self):
+        sample = [
+            {
+                'opening_price': 100,
+                'high_price': 110,
+                'low_price': 90,
+                'trade_price': 105,
+                'candle_acc_trade_volume': 123.4
+            },
+            {
+                'opening_price': 105,
+                'high_price': 112,
+                'low_price': 101,
+                'trade_price': 108,
+                'candle_acc_trade_volume': 150
+            }
+        ]
+        df = self.analyzer.prepare_dataframe(sample)
+        self.assertListEqual(list(df.columns[:5]), ['open','high','low','close','volume'])
+        self.assertEqual(len(df), 2)
+        self.assertEqual(df['close'].iloc[0], 105)
+        self.assertEqual(df['volume'].iloc[1], 150)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `prepare_dataframe` in `MarketAnalyzer`
- add unit test for the dataframe preparation

## Testing
- `pytest tests/test_prepare_dataframe.py -q`
- `pytest -q` *(fails: ConfigSync and TradingState tests)*

------
https://chatgpt.com/codex/tasks/task_e_6847dbb6d2a083299bf72f0b13409d67