### PR TITLE
Ignore delisted markets

### DIFF
--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -391,7 +391,16 @@ class MarketAnalyzer:
                 return 'NEUTRAL', 0.5
                 
             # KRW 마켓만 필터링
-            krw_markets = [item['market'] for item in markets if item['market'].startswith('KRW-')]
+            excluded = set(
+                self.config.get('trading', {})
+                .get('coin_selection', {})
+                .get('excluded_coins', [])
+            )
+            krw_markets = [
+                item['market']
+                for item in markets
+                if item['market'].startswith('KRW-') and item['market'] not in excluded
+            ]
             if not krw_markets:
                 return 'NEUTRAL', 0.5
                 
@@ -707,8 +716,17 @@ class MarketAnalyzer:
                 logger.error("마켓 정보 조회 실패")
                 return []
             
-            # KRW 마켓만 필터링
-            krw_markets = [item for item in markets if item['market'].startswith('KRW-')]
+            # KRW 마켓만 필터링하며 제외 코인은 제거
+            excluded = set(
+                self.config.get('trading', {})
+                .get('coin_selection', {})
+                .get('excluded_coins', [])
+            )
+            krw_markets = [
+                item
+                for item in markets
+                if item['market'].startswith('KRW-') and item['market'] not in excluded
+            ]
             logger.info(f"전체 마켓 수: {len(krw_markets)}")
             
             # 마켓 코드 리스트 생성

--- a/trading/data/market_data.py
+++ b/trading/data/market_data.py
@@ -71,7 +71,11 @@ class MarketData:
             
             # 가격 범위 내의 코인 필터링
             investable = self.exchange.get_investable_tickers(min_price, max_price)
-            
+
+            # 제외 코인은 조회하지 않도록 필터링
+            excluded = set(coin_sel.get('excluded_coins', []))
+            investable = [ticker for ticker in investable if ticker not in excluded]
+
             # 24시간 거래대금 및 1시간 평균 거래대금 필터링
             tradable = []
             for ticker in investable:


### PR DESCRIPTION
## Summary
- filter out excluded coins before requests in `MarketAnalyzer`
- avoid querying excluded coins when building tradable list

## Testing
- `pip install -q pandas numpy requests scipy pyjwt python-dotenv`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: jwt / dotenv etc then functional assertions)*

------
https://chatgpt.com/codex/tasks/task_e_6847dd878fa483299f3aec3a11b4a05a