### PR TITLE
Fix Flask server startup

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ ta==0.7.0
 websockets==9.1
 python-telegram-bot==13.7
 concurrent-log-handler==0.9.24
+Werkzeug==2.0.1


### PR DESCRIPTION
## Summary
- avoid eventlet import by forcing threading mode
- provide dummy API keys for tests
- relax config validation for nested flags
- remove obsolete allow_unsafe_werkzeug option
- pin Werkzeug for Flask compatibility

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847e61d41dc832997066dea4a94964d