### PR TITLE
Add deep-merge config updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ python web/app.py
 4. 웹 인터페이스 접속
 - http://localhost:5000 접속
 - 설정 페이지: http://localhost:5000/settings
+- 설정을 변경하고 저장하면 `config.json` 파일에 기록되어 재시작 후에도 유지됩니다.
 - 대시보드: http://localhost:5000/dashboard
 
 ## 문제 해결(Troubleshooting)

--- a/core/config.py
+++ b/core/config.py
@@ -529,13 +529,15 @@ class Config:
     def get_config(self) -> Dict[str, Any]:
         """
         현재 설정값 반환
-        
+
         현재 설정의 복사본을 반환합니다.
         복사본을 반환함으로써 실수로 설정이 변경되는 것을 방지합니다.
-        
+
         Returns:
             Dict[str, Any]: 현재 설정값의 복사본
         """
+        # 파일이 외부에서 수정되었을 수 있으므로 매 호출 시 최신 설정을 로드한다
+        self.config = self.load_config()
         cfg = self.config.copy()
 
         if "trading" in cfg:

--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -143,10 +143,18 @@ class MarketAnalyzer:
         """설정 업데이트"""
         try:
             logger.info("설정 업데이트 시작")
-            
-            # 기존 설정과 새로운 설정 병합
-            self.config.update(new_config)
-            
+
+            # 기존 설정과 새로운 설정 병합 (깊은 병합으로 누락된 값 보존)
+            def deep_merge(src, updates):
+                for k, v in updates.items():
+                    if isinstance(v, dict) and isinstance(src.get(k), dict):
+                        src[k] = deep_merge(src.get(k, {}), v)
+                    else:
+                        src[k] = v
+                return src
+
+            self.config = deep_merge(self.config, new_config)
+
             # 설정 파일 저장
             with open(self.config_path, 'w', encoding='utf-8') as f:
                 json.dump(self.config, f, indent=4, ensure_ascii=False)


### PR DESCRIPTION
## Summary
- reload configuration when queried so file updates propagate
- preserve existing settings on MarketAnalyzer.update_config via deep merge

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847ee54d8f08329a3c31846f2d3675d