### PR TITLE
Adjust default trading configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,14 +2,14 @@
     "version": "1.0.0",
     "trading": {
         "enabled": true,
-        "investment_amount": 10000.0,
-        "max_coins": 8,
+        "investment_amount": 200000.0,
+        "max_coins": 5,
         "coin_selection": {
             "min_price": 700.0,
             "max_price": 26666.0,
             "min_volume_24h": 1400000000,
-            "min_volume_1h": 100000000,
-            "min_tick_ratio": 0.04,
+            "min_volume_1h": 10000000,
+            "min_tick_ratio": 0.035,
             "excluded_coins": [
                 "KRW-ETHW",
                 "KRW-ETHF",

--- a/config/default_settings.py
+++ b/config/default_settings.py
@@ -23,7 +23,7 @@ DEFAULT_SETTINGS = {
     "version": "1.0.0",
     "trading": {
         "enabled": True,
-        "investment_amount": 10000,
+        "investment_amount": 200000,
         "max_coins": 5,
         "coin_selection": DEFAULT_COIN_SELECTION.copy()
     },

--- a/core/config.py
+++ b/core/config.py
@@ -127,14 +127,14 @@ class Config:
         "version": "1.0.0",
         "trading": {
             "enabled": True,
-            "investment_amount": 100000,
+            "investment_amount": 200000,
             "max_coins": 5,
             "coin_selection": {
-                "min_price": 100,
+                "min_price": 700,
                 "max_price": 26666,
                 "min_volume_24h": 1400000000,
-                "min_volume_1h": 100000000,
-                "min_tick_ratio": 0.04
+                "min_volume_1h": 10000000,
+                "min_tick_ratio": 0.035
             }
         },
         "signals": {

--- a/core/constants.py
+++ b/core/constants.py
@@ -3,7 +3,7 @@ DEFAULT_COIN_SELECTION = {
     "min_price": 700,
     "max_price": 26666,
     "min_volume_24h": 1400000000,
-    "min_volume_1h": 100000000,
-    "min_tick_ratio": 0.04,
+    "min_volume_1h": 10000000,
+    "min_tick_ratio": 0.035,
     "excluded_coins": ["KRW-ETHW", "KRW-ETHF", "KRW-XCORE", "KRW-GAS", "KRW-BTS"],
 }

--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -709,8 +709,8 @@ class MarketAnalyzer:
             min_price = settings.get('min_price', 700)
             max_price = settings.get('max_price', 26666)
             min_volume_24h = settings.get('min_volume_24h', 1400000000)
-            min_volume_1h = settings.get('min_volume_1h', 100000000)
-            min_tick_ratio = settings.get('min_tick_ratio', 0.04)
+            min_volume_1h = settings.get('min_volume_1h', 10000000)
+            min_tick_ratio = settings.get('min_tick_ratio', 0.035)
 
             logger.info(
                 f"코인 선정 기준: 가격 {min_price}~{max_price}원, 24h≥{min_volume_24h}, 1h≥{min_volume_1h}, 틱비율≥{min_tick_ratio}%"

--- a/settings.json
+++ b/settings.json
@@ -1,11 +1,11 @@
 {
-  "investment_amount": 10000,
+  "investment_amount": 200000,
   "max_coins": 5,
   "min_price": 700,
   "max_price": 26666,
   "min_volume_24h": 1400000000,
-  "min_volume_1h": 100000000,
-  "min_tick_ratio": 0.04,
+  "min_volume_1h": 10000000,
+  "min_tick_ratio": 0.035,
   "buy_conditions": {
     "bullish_rsi": 40,
     "neutral_rsi": 35,

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -14,15 +14,15 @@ let currentSettings = {};
 const recommendedSettings = {
     trading: {
         enabled: false,  // 실제 매매 실행 여부
-        investment_amount: 10000,    // 1만원 단위 테스트 추천
-        max_coins: 8,               // 동시 보유 최대 8개 코인
+        investment_amount: 200000,    // 기본 투자금액
+        max_coins: 5,               // 동시 보유 최대 5개 코인
         coin_selection: {
             // 기본값 업데이트
             min_price: 700,         // 최소 가격 (원)
             max_price: 26666,       // 최대 가격 (원)
             min_volume_24h: 1400000000,
-            min_volume_1h: 100000000,
-            min_tick_ratio: 0.04,
+            min_volume_1h: 10000000,
+            min_tick_ratio: 0.035,
             excluded_coins: []
         }
     },


### PR DESCRIPTION
## Summary
- raise default investment amount to 200000 KRW
- set default min_price to 700 KRW
- update coin selection defaults (1h volume and tick ratio)
- sync new defaults across backend and frontend configs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6847f625ec048329be383eb6228a6fc1