### PR TITLE
Remove unused trade_settings section

### DIFF
--- a/config.json
+++ b/config.json
@@ -178,16 +178,6 @@
         },
         "check_interval_minutes": 15
     },
-    "trade_settings": {
-        "base_amount": 10000,
-        "max_positions": 5,
-        "risk_per_trade": 0.01,
-        "min_price": 700,
-        "max_price": 26666,
-        "min_volume_24h": 1400000000,
-        "min_volume_1h": 100000000,
-        "min_tick_ratio": 0.04
-    },
     "indicators": {
         "rsi_period": 14,
         "rsi_oversold": 30,


### PR DESCRIPTION
## Summary
- clean up `config.json` by removing the unused `trade_settings`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `python3 run.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6847fa98a16c8329be7179153a6eb659