### PR TITLE
Improve buy signal logging

### DIFF
--- a/trading/bot/trading_bot.py
+++ b/trading/bot/trading_bot.py
@@ -142,7 +142,9 @@ class TradingBot:
                     continue
                     
                 # 매수 신호 확인
-                if self.strategy.check_buy_signal(symbol, df_1m, df_15m):
+                signal, score = self.strategy.check_buy_signal(symbol, df_1m, df_15m)
+                if signal:
+                    self.logger.info(f"{symbol} 매수 시도")
                     success, order_info = self.order_manager.buy_with_settings(symbol, self.buy_settings)
                     if success and order_info:
                         executed_volume = float(order_info.get('executed_volume', 0))
@@ -166,6 +168,8 @@ class TradingBot:
 
                             if len(self.strategy.positions) >= self.settings['trading']['max_coins']:
                                 break
+                    else:
+                        self.logger.warning(f"{symbol} 매수 주문 실패")
 
             except Exception as e:
                 self.logger.error(f"{symbol} 매수 신호 확인 실패: {str(e)}")

--- a/trading/strategies/one_min_strategy.py
+++ b/trading/strategies/one_min_strategy.py
@@ -20,17 +20,24 @@ class OneMinStrategy:
         self.logger = TradingLogger("OneMinStrategy")
         self.positions: Dict[str, Dict] = {}  # 보유 포지션 정보
         
-    def check_buy_signal(self, symbol: str, df_1m: pd.DataFrame, df_15m: pd.DataFrame) -> bool:
-        """점수 기반 매수 신호 확인"""
+    def check_buy_signal(
+        self, symbol: str, df_1m: pd.DataFrame, df_15m: pd.DataFrame
+    ) -> Tuple[bool, float]:
+        """점수 기반 매수 신호 확인
+
+        Returns:
+            Tuple[bool, float]: (매수 신호 여부, 계산된 점수)
+        """
         if len(df_1m) < 20 or len(df_15m) < 20:
-            return False
+            return False, 0.0
 
         score = self._calculate_score(symbol, df_1m)
         threshold = self.settings.get('buy_score', {}).get('score_threshold', 0)
-        if score >= threshold:
-            self.logger.info(f"{symbol} 매수 점수 {score} / {threshold}")
-            return True
-        return False
+
+        # 점수와 임계값을 항상 기록하여 디버깅에 활용한다
+        self.logger.info(f"{symbol} 매수 점수 {score} / {threshold}")
+
+        return score >= threshold, score
 
     def _calculate_score(self, symbol: str, df_1m: pd.DataFrame) -> float:
         conf = self.settings.get('buy_score', {})


### PR DESCRIPTION
## Summary
- log score comparisons for every buy signal check
- show when buy orders are attempted and warn if they fail

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684837867b508329ad2c853293ed9eb0