### PR TITLE
Set LIMIT_WAIT_SEC_2 default to 0

### DIFF
--- a/config.json
+++ b/config.json
@@ -123,7 +123,7 @@
         "ENTRY_SIZE_INITIAL": 7000,
         "LIMIT_WAIT_SEC_1": 30,
         "1st_Bid_Price": "BID1+",
-        "LIMIT_WAIT_SEC_2": 20,
+        "LIMIT_WAIT_SEC_2": 0,
         "2nd_Bid_Price": "ASK1"
     },
     "sell_settings": {

--- a/config/default_settings.py
+++ b/config/default_settings.py
@@ -10,7 +10,7 @@ DEFAULT_BUY_SETTINGS = {
     "ENTRY_SIZE_INITIAL": 7000,
     "LIMIT_WAIT_SEC_1": 30,
     "1st_Bid_Price": "BID1+",
-    "LIMIT_WAIT_SEC_2": 20,
+    "LIMIT_WAIT_SEC_2": 0,
     "2nd_Bid_Price": "ASK1",
 }
 


### PR DESCRIPTION
## Summary
- default second wait setting is now disabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684838e88a54832981c39fe1a3072ee9