### PR TITLE
Fix market status update

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -351,6 +351,17 @@
                 updateMonitoredCoinsTable(data.coins);
             });
 
+            socket.on('market_analysis', (data) => {
+                console.log('Market analysis update:', data);
+                const condition = data.market_condition || '-';
+                const confidence = data.confidence ? `${(data.confidence * 100).toFixed(2)}%` : '-';
+                const timestamp = data.timestamp || '-';
+
+                document.getElementById('marketCondition').textContent = condition;
+                document.getElementById('marketConfidence').textContent = confidence;
+                document.getElementById('lastUpdate').textContent = timestamp;
+            });
+
             socket.on('market_buy_result', (data) => {
                 if (data.success) {
                     showNotification(data.message, 'success');


### PR DESCRIPTION
## Summary
- handle `market_analysis` socket event on home page so market status updates

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68483b75671c8329b8702469e1fac6f7