### PR TITLE
Fix missing API key handling and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,24 @@
 pip install -r requirements.txt
 ```
 
-2. 설정 파일 구성
+2. 환경 변수 설정
+프로젝트 루트에 `.env` 파일을 생성하고 다음 값을 입력합니다.
+```env
+UPBIT_ACCESS_KEY=your_access_key
+UPBIT_SECRET_KEY=your_secret_key
+```
+실제 키로 교체한 후 저장하세요.
+
+3. 설정 파일 구성
 - `config.json` 파일에서 기본 설정 구성
 - 웹 인터페이스에서 설정 변경 가능
 
-3. 서버 실행
+4. 서버 실행
 ```bash
 python web/app.py
 ```
 
-4. 웹 인터페이스 접속
+5. 웹 인터페이스 접속
 - http://localhost:5000 접속
 - 설정 페이지: http://localhost:5000/settings
 - 설정을 변경하고 저장하면 `config.json` 파일에 기록되어 재시작 후에도 유지됩니다.

--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -95,9 +95,9 @@ class MarketAnalyzer:
         # API 키 설정
         self.access_key = os.getenv('UPBIT_ACCESS_KEY')
         self.secret_key = os.getenv('UPBIT_SECRET_KEY')
-        
+
         if not self.access_key or not self.secret_key:
-            raise ValueError("API 키가 설정되지 않았습니다. .env 파일을 확인해주세요.")
+            logger.warning("API 키가 설정되지 않았습니다. .env 파일을 확인해주세요.")
             
         # 설정 로드
         self.config = self.load_config()

--- a/web/app.py
+++ b/web/app.py
@@ -27,10 +27,6 @@ from core.constants import DEFAULT_COIN_SELECTION
 dotenv_path = Path(__file__).resolve().parents[1] / '.env'
 load_dotenv(dotenv_path)
 
-# 테스트 환경을 위한 기본 API 키 값 설정
-os.environ.setdefault("UPBIT_ACCESS_KEY", "test")
-os.environ.setdefault("UPBIT_SECRET_KEY", "test")
-
 app = Flask(__name__, 
     template_folder='../templates',
     static_folder='../static'


### PR DESCRIPTION
## Summary
- remove default `UPBIT_*` API keys from `web/app.py`
- warn instead of raising when API keys are missing in `MarketAnalyzer`
- document required `.env` file in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68483d2bf7f88329a0be458ed188a592