### PR TITLE
Add Telegram notifications

### DIFF
--- a/core/telegram_notifier.py
+++ b/core/telegram_notifier.py
@@ -21,7 +21,10 @@ from pathlib import Path
 import logging
 
 dotenv_path = Path(__file__).resolve().parents[1] / '.env'
-load_dotenv(dotenv_path)
+if dotenv_path.exists():
+    load_dotenv(dotenv_path)
+else:
+    load_dotenv()
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- integrate `TelegramNotifier` with `TradingLogger`
- send Telegram messages for trades, signals, errors and system metrics when credentials are available
- improve `.env` loading by falling back to default path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68483c945afc8329bd96abd3ba6a65b5