### PR TITLE
Enable resizable columns on home page

### DIFF
--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -331,7 +331,7 @@ class ConfigManager:
             merged = deep_merge(json.loads(json.dumps(self.config)), nested_config)
 
             # 설정 검증
-            self._validate_config(merged)
+            self._validate_config(merged, new_config)
 
             # 병합된 설정으로 갱신
             self.config = merged
@@ -358,7 +358,7 @@ class ConfigManager:
             print(f"설정 업데이트 실패: {e}")
             raise ValueError(f"설정 업데이트 실패: {e}")
             
-    def _validate_config(self, config: Dict[str, Any]):
+    def _validate_config(self, config: Dict[str, Any], updates: Dict[str, Any] | None = None):
         """
         설정값 유효성 검사
         
@@ -390,4 +390,24 @@ class ConfigManager:
             if 'investment_amount' in trading and trading['investment_amount'] <= 0:
                 raise ValueError("투자 금액은 0보다 커야 합니다.")
             if 'max_coins' in trading and trading['max_coins'] <= 0:
-                raise ValueError("최대 보유 코인 수는 0보다 커야 합니다.") 
+                raise ValueError("최대 보유 코인 수는 0보다 커야 합니다.")
+
+        # RSI 및 손절/익절 설정 검증
+        if 'signals' in config:
+            signals = config['signals']
+            common = signals.get('common_conditions', {})
+            rsi_common = common.get('rsi', {})
+            if rsi_common.get('enabled'):
+                period = rsi_common.get('period', 14)
+                if period <= 0 or period > 100:
+                    raise ValueError("RSI 기간은 1에서 100 사이여야 합니다.")
+
+            stop_loss_updated = updates and 'stop_loss' in updates
+            take_profit_updated = updates and 'take_profit' in updates
+
+            sell_conditions = signals.get('sell_conditions', {})
+            stop_loss = sell_conditions.get('stop_loss', {})
+            take_profit = sell_conditions.get('take_profit', {})
+            if stop_loss.get('enabled') and take_profit.get('enabled') and stop_loss_updated and take_profit_updated:
+                if abs(stop_loss.get('threshold', 0)) >= take_profit.get('threshold', 0):
+                    raise ValueError("손절 임계값은 익절 임계값보다 작아야 합니다.")

--- a/templates/index.html
+++ b/templates/index.html
@@ -116,6 +116,21 @@
         .btn-danger {
             border-radius: var(--border-radius);
         }
+
+        .resizable-container {
+            display: flex;
+            width: 100%;
+        }
+
+        .resizable-panel {
+            overflow: auto;
+        }
+
+        .resizer {
+            width: 5px;
+            cursor: ew-resize;
+            background-color: var(--background-color);
+        }
     </style>
 </head>
 <body>
@@ -141,9 +156,9 @@
 
     <div class="container-fluid py-4">
         <!-- 전체 화면을 활용하도록 너비 조정 -->
-        <div class="row" style="width:100%; margin:0 auto;">
+        <div id="mainRow" class="row resizable-container" style="width:100%; margin:0 auto;">
             <!-- 좌측 컨트롤 패널 -->
-            <div class="col-md-4">
+            <div id="leftPanel" class="col-md-4 resizable-panel" style="min-width:250px; width:33%;">
                 <!-- 봇 컨트롤 -->
                 <div class="card">
                     <div class="card-header">
@@ -209,9 +224,10 @@
                     </div>
                 </div>
             </div>
+            <div id="columnResizer" class="resizer"></div>
 
             <!-- 우측 메인 컨텐츠 -->
-            <div class="col-md-8">
+            <div id="rightPanel" class="col-md-8 resizable-panel" style="min-width:300px;">
                 <!-- 보유 코인 -->
                 <div class="card">
                     <div class="card-header">
@@ -526,7 +542,39 @@
 
             // 페이지 로드 시 초기 데이터 요청
             socket.emit('request_initial_data');
+
+            const resizer = document.getElementById('columnResizer');
+            const leftPanel = document.getElementById('leftPanel');
+            const rightPanel = document.getElementById('rightPanel');
+            const container = document.getElementById('mainRow');
+
+            if (resizer && leftPanel && rightPanel && container) {
+                let startX = 0;
+                let startLeftWidth = 0;
+
+                const doDrag = (e) => {
+                    const containerRect = container.getBoundingClientRect();
+                    let newLeftWidth = startLeftWidth + e.clientX - startX;
+                    const minLeftWidth = 200;
+                    const maxLeftWidth = containerRect.width - 200;
+                    newLeftWidth = Math.max(minLeftWidth, Math.min(maxLeftWidth, newLeftWidth));
+                    leftPanel.style.width = newLeftWidth + 'px';
+                    rightPanel.style.width = (containerRect.width - newLeftWidth - resizer.offsetWidth) + 'px';
+                };
+
+                const stopDrag = () => {
+                    document.removeEventListener('mousemove', doDrag);
+                    document.removeEventListener('mouseup', stopDrag);
+                };
+
+                resizer.addEventListener('mousedown', (e) => {
+                    startX = e.clientX;
+                    startLeftWidth = leftPanel.getBoundingClientRect().width;
+                    document.addEventListener('mousemove', doDrag);
+                    document.addEventListener('mouseup', stopDrag);
+                });
+            }
         });
     </script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- add draggable column layout on `index.html`
- validate RSI period and optional stop loss/take profit relationship in `ConfigManager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684844f580288329876f6a853d62f4e0