### PR TITLE
Reduce logging of socketio sessions

### DIFF
--- a/config/logging_config.py
+++ b/config/logging_config.py
@@ -43,8 +43,10 @@ def setup_logging():
     logger.addHandler(file_handler)
     logger.addHandler(console_handler)
 
-    # suppress werkzeug request logs
+    # suppress noisy library logs
     logging.getLogger('werkzeug').setLevel(logging.WARNING)
+    logging.getLogger('engineio').setLevel(logging.WARNING)
+    logging.getLogger('socketio').setLevel(logging.WARNING)
 
     # 시작 로그
     logger.info('='*80)


### PR DESCRIPTION
## Summary
- cut down log noise by setting engineio and socketio log levels to `WARNING`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6848519032688329b6e9d7ed57e05754