### PR TITLE
Lower min volume 1h

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
             "min_price": 700,
             "max_price": 26666,
             "min_volume_24h": 1400000000,
-            "min_volume_1h": 20000000,
+            "min_volume_1h": 10000000,
             "min_tick_ratio": 0.035,
             "excluded_coins": [
                 "KRW-ETHW",

--- a/core/constants.py
+++ b/core/constants.py
@@ -3,7 +3,7 @@ DEFAULT_COIN_SELECTION = {
     "min_price": 700,
     "max_price": 26666,
     "min_volume_24h": 1400000000,
-    "min_volume_1h": 20000000,
+    "min_volume_1h": 10000000,
     "min_tick_ratio": 0.035,
     "excluded_coins": ["KRW-ETHW", "KRW-ETHF", "KRW-XCORE", "KRW-GAS", "KRW-BTS"],
 }

--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -756,7 +756,7 @@ class MarketAnalyzer:
             min_price = settings.get('min_price', 700)
             max_price = settings.get('max_price', 26666)
             min_volume_24h = settings.get('min_volume_24h', 1400000000)
-            min_volume_1h = settings.get('min_volume_1h', 20000000)
+            min_volume_1h = settings.get('min_volume_1h', 10000000)
             min_tick_ratio = settings.get('min_tick_ratio', 0.035)
 
             logger.info(

--- a/settings.json
+++ b/settings.json
@@ -4,7 +4,7 @@
   "min_price": 700,
   "max_price": 26666,
   "min_volume_24h": 1400000000,
-  "min_volume_1h": 20000000,
+  "min_volume_1h": 10000000,
   "min_tick_ratio": 0.035,
   "buy_conditions": {
     "bullish_rsi": 40,

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -21,7 +21,7 @@ const recommendedSettings = {
             min_price: 700,         // 최소 가격 (원)
             max_price: 26666,       // 최대 가격 (원)
             min_volume_24h: 1400000000,
-            min_volume_1h: 20000000,
+            min_volume_1h: 10000000,
             min_tick_ratio: 0.035,
             excluded_coins: []
         }


### PR DESCRIPTION
## Summary
- adjust 1h trading volume minimum from 20M to 10M

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68485a4e8b1483298f9186091fd0a4c5