### PR TITLE
Fix log encoding

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -56,7 +56,7 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler('trading.log'),
+        logging.FileHandler('trading.log', encoding='utf-8'),
         logging.StreamHandler()
     ]
 )

--- a/core/logger.py
+++ b/core/logger.py
@@ -69,7 +69,9 @@ class TradingLogger:
         
         # 파일 핸들러 설정 (일별 로그 파일)
         today = datetime.now().strftime('%Y%m%d')
-        fh = logging.FileHandler(f'{self.log_dir}/trading_{today}.log')
+        fh = logging.FileHandler(
+            f'{self.log_dir}/trading_{today}.log', encoding='utf-8'
+        )
         fh.setLevel(logging.INFO)
         
         # 콘솔 핸들러 설정 (실시간 모니터링용)

--- a/core/performance.py
+++ b/core/performance.py
@@ -17,7 +17,7 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler('trading.log'),
+        logging.FileHandler('trading.log', encoding='utf-8'),
         logging.StreamHandler()
     ]
 )

--- a/run.py
+++ b/run.py
@@ -8,7 +8,7 @@ logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler('trading.log'),
+        logging.FileHandler('trading.log', encoding='utf-8'),
         logging.StreamHandler()
     ]
 )


### PR DESCRIPTION
## Summary
- ensure logs are written using UTF-8 across modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684863a3ad60832985d1b593f5e3b6a4