### PR TITLE
Remove deprecated signals feature

### DIFF
--- a/config.json
+++ b/config.json
@@ -19,63 +19,6 @@
             ]
         }
     },
-    "signals": {
-        "enabled": false,
-        "buy_conditions": {
-            "bull": {
-                "rsi": 40,
-                "sigma": 1.8,
-                "vol_prev": 1.5,
-                "vol_ma": 1.2,
-                "slope": 0.12
-            },
-            "range": {
-                "rsi": 35,
-                "sigma": 2.0,
-                "vol_prev": 2.0,
-                "vol_ma": 1.5,
-                "slope": 0.1
-            },
-            "bear": {
-                "rsi": 30,
-                "sigma": 2.2,
-                "vol_prev": 2.5,
-                "vol_ma": 1.8,
-                "slope": 0.08
-            },
-            "enabled": {
-                "trend_filter": true,
-                "bull_filter": false,
-                "golden_cross": true,
-                "rsi": true,
-                "bollinger": true,
-                "volume_surge": true
-            }
-        },
-        "sell_conditions": {
-            "enabled": true,
-            "stop_loss": {
-                "enabled": true,
-                "threshold": -2.5,
-                "trailing_stop": 0.5
-            },
-            "take_profit": {
-                "enabled": true,
-                "threshold": 5.0,
-                "trailing_profit": 1.0
-            },
-            "dead_cross": {
-                "enabled": true
-            },
-            "rsi": {
-                "enabled": true,
-                "threshold": 60
-            },
-            "bollinger": {
-                "enabled": true
-            }
-        }
-    },
     "notifications": {
         "trade": {
             "start": true,

--- a/config/default_settings.py
+++ b/config/default_settings.py
@@ -39,63 +39,6 @@ DEFAULT_SETTINGS = {
         },
         "check_interval_minutes": 15
     },
-    "signals": {
-        "enabled": False,
-        "buy_conditions": {
-            "bull": {
-                "rsi": 40,
-                "sigma": 1.8,
-                "vol_prev": 1.5,
-                "vol_ma": 1.2,
-                "slope": 0.12
-            },
-            "range": {
-                "rsi": 35,
-                "sigma": 2.0,
-                "vol_prev": 2.0,
-                "vol_ma": 1.5,
-                "slope": 0.10
-            },
-            "bear": {
-                "rsi": 30,
-                "sigma": 2.2,
-                "vol_prev": 2.5,
-                "vol_ma": 1.8,
-                "slope": 0.08
-            },
-            "enabled": {
-                "trend_filter": True,
-                "bull_filter": False,
-                "golden_cross": True,
-                "rsi": True,
-                "bollinger": True,
-                "volume_surge": True
-            }
-        },
-        "sell_conditions": {
-            "enabled": True,
-            "stop_loss": {
-                "enabled": True,
-                "threshold": -2.5,
-                "trailing_stop": 0.5
-            },
-            "take_profit": {
-                "enabled": True,
-                "threshold": 5.0,
-                "trailing_profit": 1.0
-            },
-            "dead_cross": {
-                "enabled": True
-            },
-            "rsi": {
-                "enabled": True,
-                "threshold": 60
-            },
-            "bollinger": {
-                "enabled": True
-            }
-        }
-    },
     "notifications": {
         "trade": {
             "start": True,

--- a/core/config.py
+++ b/core/config.py
@@ -297,83 +297,6 @@ class Config:
         if coin_selection.get('min_tick_ratio', 0) < 0:
             raise ConfigError("호가 틱당 가격 변동률은 0 이상이어야 합니다.")
         
-        # === 매매 신호 설정 검증 ===
-        signals_config = config.get('signals', {})
-        if not signals_config.get('enabled', True):
-            return
-
-        # === 매도 조건 검증 ===
-        sell_conditions = signals_config.get('sell_conditions', {})
-        if sell_conditions.get('enabled', True):
-            stop_loss = sell_conditions.get('stop_loss', {})
-            take_profit = sell_conditions.get('take_profit', {})
-            
-            if stop_loss.get('enabled', False):
-                if not isinstance(stop_loss.get('threshold'), (int, float)):
-                    raise ConfigError("손절 임계값은 숫자여야 합니다.")
-                if stop_loss.get('threshold', 0) >= 0:
-                    raise ConfigError("손절 임계값은 0보다 작아야 합니다.")
-            
-            if take_profit.get('enabled', False):
-                if not isinstance(take_profit.get('threshold'), (int, float)):
-                    raise ConfigError("익절 임계값은 숫자여야 합니다.")
-                if take_profit.get('threshold', 0) <= 0:
-                    raise ConfigError("익절 임계값은 0보다 커야 합니다.")
-        
-        # === RSI 설정 검증 ===
-        common_conditions = signals_config.get('common_conditions', {})
-        if common_conditions.get('enabled', True):
-            rsi_config = common_conditions.get('rsi', {})
-            if rsi_config.get('enabled', False):
-                if not (0 < rsi_config.get('period', 14) <= 100):
-                    raise ConfigError("RSI 기간은 1에서 100 사이여야 합니다.")
-
-        buy_conditions = signals_config.get('buy_conditions', {})
-        if buy_conditions.get('enabled', True):
-            rsi_buy = buy_conditions.get('rsi', {})
-            if rsi_buy.get('enabled', False) and not (0 <= rsi_buy.get('threshold', 30) <= 100):
-                raise ConfigError("RSI 매수 임계값은 0에서 100 사이여야 합니다.")
-
-        sell_conditions = signals_config.get('sell_conditions', {})
-        if sell_conditions.get('enabled', True):
-            rsi_sell = sell_conditions.get('rsi', {})
-            if rsi_sell.get('enabled', False) and not (0 <= rsi_sell.get('threshold', 70) <= 100):
-                raise ConfigError("RSI 매도 임계값은 0에서 100 사이여야 합니다.")
-        
-        # === Golden/Dead Cross 설정 검증 ===
-        if buy_conditions.get('enabled', True):
-            golden_cross = buy_conditions.get('golden_cross', {})
-            if golden_cross.get('enabled', False):
-                if golden_cross.get('short_period', 0) <= 0:
-                    raise ConfigError("Golden Cross 단기 EMA 기간은 0보다 커야 합니다.")
-                
-                if golden_cross.get('long_period', 0) <= 0:
-                    raise ConfigError("Golden Cross 장기 EMA 기간은 0보다 커야 합니다.")
-                
-                if golden_cross.get('short_period', 5) >= golden_cross.get('long_period', 20):
-                    raise ConfigError("Golden Cross 단기 EMA 기간은 장기 EMA 기간보다 작아야 합니다.")
-
-        if sell_conditions.get('enabled', True):
-            dead_cross = sell_conditions.get('dead_cross', {})
-            if dead_cross.get('enabled', False):
-                if dead_cross.get('short_period', 0) <= 0:
-                    raise ConfigError("Dead Cross 단기 EMA 기간은 0보다 커야 합니다.")
-                
-                if dead_cross.get('long_period', 0) <= 0:
-                    raise ConfigError("Dead Cross 장기 EMA 기간은 0보다 커야 합니다.")
-                
-                if dead_cross.get('short_period', 5) >= dead_cross.get('long_period', 20):
-                    raise ConfigError("Dead Cross 단기 EMA 기간은 장기 EMA 기간보다 작아야 합니다.")
-        
-        # === 볼린저 밴드 설정 검증 ===
-        if common_conditions.get('enabled', True):
-            bollinger = common_conditions.get('bollinger', {})
-            if bollinger.get('enabled', False):
-                if bollinger.get('period', 0) <= 0:
-                    raise ConfigError("볼린저 밴드 기간은 0보다 커야 합니다.")
-                
-                if bollinger.get('k', 0) <= 0:
-                    raise ConfigError("볼린저 밴드 표준편차 배수는 0보다 커야 합니다.")
     
     def update_config(self, new_config: Dict[str, Any]):
         """
@@ -426,29 +349,6 @@ class Config:
             cfg["min_volume_1h"] = coin.get("min_volume_1h")
             cfg["min_tick_ratio"] = coin.get("min_tick_ratio")
 
-        if "signals" in cfg:
-            signals = cfg["signals"]
-            common = signals.get("common_conditions", {})
-            rsi_common = common.get("rsi", {})
-            cfg["rsi_enabled"] = rsi_common.get("enabled")
-            cfg["rsi_period"] = rsi_common.get("period")
-            bollinger = common.get("bollinger", {})
-            cfg["bollinger_enabled"] = bollinger.get("enabled")
-
-            buy = signals.get("buy_conditions", {})
-            rsi_buy = buy.get("rsi", {})
-            cfg["rsi_buy_enabled"] = rsi_buy.get("enabled")
-            cfg["rsi_buy_threshold"] = rsi_buy.get("threshold")
-
-            sell = signals.get("sell_conditions", {})
-            rsi_sell = sell.get("rsi", {})
-            cfg["rsi_sell_enabled"] = rsi_sell.get("enabled")
-            cfg["rsi_sell_threshold"] = rsi_sell.get("threshold")
-
-            stop_loss = sell.get("stop_loss", {})
-            cfg["stop_loss_enabled"] = stop_loss.get("enabled")
-            if "threshold" in stop_loss:
-                cfg["stop_loss"] = abs(stop_loss.get("threshold"))
 
         return cfg
 

--- a/core/telegram_notifier.py
+++ b/core/telegram_notifier.py
@@ -403,13 +403,6 @@ class TelegramNotifier:
             message += f"- 방향: {trend['direction']}\n"
             message += f"- 강도: {trend['strength']}\n"
             
-        # 거래 신호
-        if 'signals' in analysis:
-            signals = analysis['signals']
-            message += f"\n🎯 거래 신호:\n"
-            for signal, value in signals.items():
-                emoji = "✅" if value else "❌"
-                message += f"- {signal}: {emoji}\n"
                 
         await self.send_message(message)
         

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -153,36 +153,6 @@ function updateFormValues(settings) {
     setValue('trading.min_volume_1h', settings.trading?.coin_selection?.min_volume_1h);
     setValue('trading.min_tick_ratio', settings.trading?.coin_selection?.min_tick_ratio);
 
-    // 매수 지표 설정
-    const buyConditions = settings.signals?.buy_conditions || {};
-    
-    // 상승장 설정
-    setValue('signals.buy_conditions.bull.rsi', buyConditions.bull?.rsi);
-    setValue('signals.buy_conditions.bull.sigma', buyConditions.bull?.sigma);
-    setValue('signals.buy_conditions.bull.vol_prev', buyConditions.bull?.vol_prev);
-    setValue('signals.buy_conditions.bull.vol_ma', buyConditions.bull?.vol_ma);
-    setValue('signals.buy_conditions.bull.slope', buyConditions.bull?.slope);
-
-    // 박스장 설정
-    setValue('signals.buy_conditions.range.rsi', buyConditions.range?.rsi);
-    setValue('signals.buy_conditions.range.sigma', buyConditions.range?.sigma);
-    setValue('signals.buy_conditions.range.vol_prev', buyConditions.range?.vol_prev);
-    setValue('signals.buy_conditions.range.vol_ma', buyConditions.range?.vol_ma);
-    setValue('signals.buy_conditions.range.slope', buyConditions.range?.slope);
-
-    // 하락장 설정
-    setValue('signals.buy_conditions.bear.rsi', buyConditions.bear?.rsi);
-    setValue('signals.buy_conditions.bear.sigma', buyConditions.bear?.sigma);
-    setValue('signals.buy_conditions.bear.vol_prev', buyConditions.bear?.vol_prev);
-    setValue('signals.buy_conditions.bear.vol_ma', buyConditions.bear?.vol_ma);
-    setValue('signals.buy_conditions.bear.slope', buyConditions.bear?.slope);
-
-    // 매수 조건 토글
-    setValue('signals.buy_conditions.enabled.trend_filter', buyConditions.enabled?.trend_filter);
-    setValue('signals.buy_conditions.enabled.golden_cross', buyConditions.enabled?.golden_cross);
-    setValue('signals.buy_conditions.enabled.rsi', buyConditions.enabled?.rsi);
-    setValue('signals.buy_conditions.enabled.bollinger', buyConditions.enabled?.bollinger);
-    setValue('signals.buy_conditions.enabled.volume_surge', buyConditions.enabled?.volume_surge);
 
     // 매수 주문 설정
     const buySet = settings.buy_settings || {};
@@ -251,37 +221,6 @@ function saveSettings(card = null) {
         excluded_coins: excludedCoins
     };
 
-    // 매수 조건 설정
-    settings.signals.buy_conditions = {
-        bull: {
-            rsi: getNumberValue('signals.buy_conditions.bull.rsi'),
-            sigma: getNumberValue('signals.buy_conditions.bull.sigma'),
-            vol_prev: getNumberValue('signals.buy_conditions.bull.vol_prev'),
-            vol_ma: getNumberValue('signals.buy_conditions.bull.vol_ma'),
-            slope: getNumberValue('signals.buy_conditions.bull.slope')
-        },
-        range: {
-            rsi: getNumberValue('signals.buy_conditions.range.rsi'),
-            sigma: getNumberValue('signals.buy_conditions.range.sigma'),
-            vol_prev: getNumberValue('signals.buy_conditions.range.vol_prev'),
-            vol_ma: getNumberValue('signals.buy_conditions.range.vol_ma'),
-            slope: getNumberValue('signals.buy_conditions.range.slope')
-        },
-        bear: {
-            rsi: getNumberValue('signals.buy_conditions.bear.rsi'),
-            sigma: getNumberValue('signals.buy_conditions.bear.sigma'),
-            vol_prev: getNumberValue('signals.buy_conditions.bear.vol_prev'),
-            vol_ma: getNumberValue('signals.buy_conditions.bear.vol_ma'),
-            slope: getNumberValue('signals.buy_conditions.bear.slope')
-        },
-        enabled: {
-            trend_filter: getBooleanValue('signals.buy_conditions.enabled.trend_filter'),
-            golden_cross: getBooleanValue('signals.buy_conditions.enabled.golden_cross'),
-            rsi: getBooleanValue('signals.buy_conditions.enabled.rsi'),
-            bollinger: getBooleanValue('signals.buy_conditions.enabled.bollinger'),
-            volume_surge: getBooleanValue('signals.buy_conditions.enabled.volume_surge')
-        }
-    };
 
     // 알림 설정
     settings.notifications = {
@@ -495,29 +434,12 @@ function updateSectionState(toggleId) {
         return;
     }
 
-    // 시장 자동감지 토글 처리
-    if (toggleId === 'signals.enabled') {
-        // 2열과 3열의 모든 입력 요소를 찾습니다
-        const signalSections = document.querySelectorAll('.col-md-3:nth-child(2), .col-md-3:nth-child(3)');
-        signalSections.forEach(section => {
-            const inputs = section.querySelectorAll('input, select');
-            inputs.forEach(input => {
-                if (input.id !== 'signals.enabled') {
-                    input.disabled = toggle.checked;  // 자동감지 ON이면 비활성화
-                }
-            });
-        });
-        return;
-    }
 }
 
 // 모든 섹션 상태 업데이트
 function updateAllSectionStates() {
     // 자동 거래 상태 업데이트
     updateSectionState('trading.enabled');
-    
-    // 시장 자동감지 상태 업데이트
-    updateSectionState('signals.enabled');
 }
 
 // 이벤트 리스너 설정

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -26,7 +26,6 @@ class TestSettingsAPI(unittest.TestCase):
     def test_partial_update_with_zero_volume(self):
         partial = {
             'trading': deepcopy(DEFAULT_SETTINGS['trading']),
-            'signals': deepcopy(DEFAULT_SETTINGS['signals']),
             'notifications': deepcopy(DEFAULT_SETTINGS['notifications']),
             'buy_score': deepcopy(DEFAULT_SETTINGS['buy_score']),
             'buy_settings': deepcopy(DEFAULT_SETTINGS['buy_settings']),

--- a/web/app.py
+++ b/web/app.py
@@ -103,7 +103,7 @@ def load_config():
                 logger.info("설정 파일 로드 성공")
                 
                 # 필수 섹션 확인 및 보완
-                required_sections = ['trading', 'signals', 'notifications', 'market_analysis', 'buy_score']
+                required_sections = ['trading', 'notifications', 'market_analysis', 'buy_score']
                 default_config = get_default_config()
                 
                 for section in required_sections:
@@ -170,7 +170,7 @@ def validate_config(config):
         logger.info("설정 유효성 검사 시작...")
         
         # 필수 섹션 확인
-        required_sections = ['version', 'trading', 'signals', 'notifications', 'market_analysis', 'buy_score']
+        required_sections = ['version', 'trading', 'notifications', 'market_analysis', 'buy_score']
         for section in required_sections:
             if section not in config:
                 error_msg = f"[오류] 필수 섹션 누락: {section}"
@@ -210,34 +210,6 @@ def validate_config(config):
         if not isinstance(coin_selection.get('excluded_coins', []), list):
             validation_errors.append("[오류] excluded_coins는 리스트여야 합니다.")
 
-        # 신호 설정 검증
-        signals = config.get('signals', {})
-        if not isinstance(signals.get('enabled'), bool):
-            validation_errors.append("[오류] signals.enabled는 boolean이어야 합니다.")
-            
-        # 매수/매도 조건 검증
-        for condition_type in ['buy_conditions', 'sell_conditions']:
-            conditions = signals.get(condition_type, {})
-            if not isinstance(conditions.get('enabled'), (bool, dict)):
-                validation_errors.append(
-                    f"[오류] {condition_type}.enabled는 boolean 또는 dict이어야 합니다."
-                )
-                
-            # RSI 설정 검증
-            rsi = conditions.get('rsi', {})
-            if rsi.get('enabled', False) and 'threshold' in rsi:
-                if not isinstance(rsi.get('threshold'), (int, float)):
-                    validation_errors.append(
-                        f"[오류] {condition_type}.rsi.threshold는 숫자여야 합니다."
-                    )
-                    
-            # 볼린저 밴드 설정 검증
-            bollinger = conditions.get('bollinger', {})
-            if bollinger.get('enabled', False) and 'threshold' in bollinger:
-                if not isinstance(bollinger.get('threshold'), (int, float)):
-                    validation_errors.append(
-                        f"[오류] {condition_type}.bollinger.threshold는 숫자여야 합니다."
-                    )
 
         # 알림 설정 검증
         notifications = config.get('notifications', {})
@@ -695,9 +667,6 @@ def handle_select_coin(data):
         coin_data = market_analyzer.get_coin_data(market)
         emit('market_update', coin_data)
         
-        # 매수/매도 신호 계산 및 전송
-        signals = market_analyzer.calculate_signals(market)
-        emit('trade_signals', signals)
     except Exception as e:
         error_msg = f"코인 선택 중 오류 발생: {str(e)}"
         logger.error(error_msg)
@@ -708,9 +677,6 @@ def emit_market_update(market_data):
     try:
         socketio.emit('market_update', market_data)
         
-        # 매수/매도 신호 계산 및 전송
-        signals = market_analyzer.calculate_signals(market_data['market'])
-        socketio.emit('trade_signals', signals)
 
         # 보유 코인 및 수익 현황 업데이트
         if market_data['market'] in bot_status['holdings']:


### PR DESCRIPTION
## Summary
- drop obsolete `signals` settings from config files
- strip all signals logic from configuration management
- remove signal calculation and related helpers
- clean up web UI/JS and API to exclude signals
- update tests accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684868bf13bc8329aa9478dbd014fad9