### PR TITLE
Update default trading config

### DIFF
--- a/Development guides.md
+++ b/Development guides.md
@@ -1062,8 +1062,8 @@ MONITORING_INTERVAL=10
 ```json
 {
     "trading": {
-        "investment_amount": 10000,
-        "max_coins": 5,
+        "investment_amount": 7000,
+        "max_coins": 7,
         "min_price": 700,
         "max_price": 26666
     },

--- a/config.json
+++ b/config.json
@@ -2,8 +2,8 @@
     "version": "1.0.0",
     "trading": {
         "enabled": true,
-        "investment_amount": 200000,
-        "max_coins": 5,
+        "investment_amount": 7000,
+        "max_coins": 7,
         "coin_selection": {
             "min_price": 700,
             "max_price": 26666,
@@ -160,8 +160,8 @@
         "trend_filter_on": true,
         "min_slope": 0.1
     },
-    "investment_amount": 200000,
-    "max_coins": 3,
+    "investment_amount": 7000,
+    "max_coins": 7,
     "rsi_enabled": true,
     "rsi_period": 14,
     "bollinger_enabled": false,

--- a/config/default_settings.py
+++ b/config/default_settings.py
@@ -10,8 +10,8 @@ DEFAULT_SETTINGS = {
     "version": "1.0.0",
     "trading": {
         "enabled": True,
-        "investment_amount": 200000,
-        "max_coins": 5,
+        "investment_amount": 7000,
+        "max_coins": 7,
         "coin_selection": DEFAULT_COIN_SELECTION.copy()
     },
     "market_analysis": {


### PR DESCRIPTION
## Summary
- update example config snippet in Development guides
- set default investment amount to 7000 KRW and allow up to 7 coins by default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486c99a7048329881a95b0d1bd67fb