### PR TITLE
Improve orderbook retrieval retries

### DIFF
--- a/core/upbit_api.py
+++ b/core/upbit_api.py
@@ -18,6 +18,7 @@ import hashlib
 import requests
 import logging
 import numpy as np
+import time
 from urllib.parse import urlencode
 from dotenv import load_dotenv
 from pathlib import Path
@@ -337,15 +338,42 @@ class UpbitAPI:
             self.logger.error(f"OHLCV 조회 실패: {str(e)}")
             return None
 
-    def get_orderbook(self, market: str):
-        """호가 정보 조회"""
-        try:
-            import pyupbit
-            orderbook = pyupbit.get_orderbook(ticker=market)
-            return orderbook[0] if orderbook else None
-        except Exception as e:
-            self.logger.error(f"호가 조회 실패: {str(e)}")
-            return None
+    def get_orderbook(self, market: str, retries: int = 3, delay: float = 0.1):
+        """호가 정보 조회
+
+        Args:
+            market (str): 마켓 코드
+            retries (int): 재시도 횟수
+            delay (float): 재시도 간격(초)
+
+        Returns:
+            Optional[Dict]: 호가 정보
+        """
+        last_error = None
+        for attempt in range(1, retries + 1):
+            try:
+                import pyupbit
+                orderbook = pyupbit.get_orderbook(ticker=market)
+                if orderbook:
+                    return orderbook[0]
+                last_error = ValueError("orderbook empty")
+                self.logger.error(
+                    f"호가 조회 실패: 결과 없음 (attempt {attempt}/{retries})"
+                )
+            except Exception as e:
+                last_error = e
+                self.logger.error(
+                    f"호가 조회 실패: {e!r} (attempt {attempt}/{retries})"
+                )
+
+            if attempt < retries:
+                time.sleep(delay)
+
+        if last_error:
+            self.logger.error(
+                f"호가 조회 실패: 재시도 {retries}회 후 포기 - {last_error!r}"
+            )
+        return None
 
     def get_recent_trades(self, market: str, count: int = 100):
         """최근 체결 내역 조회"""

--- a/tests/test_upbit_orderbook.py
+++ b/tests/test_upbit_orderbook.py
@@ -1,0 +1,15 @@
+import unittest
+from unittest.mock import patch
+from core.upbit_api import UpbitAPI
+
+class TestUpbitOrderbookRetries(unittest.TestCase):
+    @patch('time.sleep', return_value=None)
+    @patch('pyupbit.get_orderbook', side_effect=Exception('fail'))
+    def test_retry_on_failure(self, mock_get_orderbook, mock_sleep):
+        api = UpbitAPI(access_key='x', secret_key='y')
+        result = api.get_orderbook('KRW-BTC', retries=3, delay=0.01)
+        self.assertIsNone(result)
+        self.assertEqual(mock_get_orderbook.call_count, 3)
+        # sleep should be called retries-1 times
+        self.assertEqual(mock_sleep.call_count, 2)
+


### PR DESCRIPTION
## Summary
- retry orderbook fetch with detailed logging, waiting only between attempts
- adjust unit test for retry mechanism

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848901993108329b4b926500d532353