### PR TITLE
Adjust 1h volume setting

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
             "min_price": 700,
             "max_price": 26666,
             "min_volume_24h": 1400000000,
-            "min_volume_1h": 10000000,
+            "min_volume_1h": 80000000,
             "min_tick_ratio": 0.035,
             "excluded_coins": [
                 "KRW-ETHW",

--- a/core/constants.py
+++ b/core/constants.py
@@ -3,7 +3,7 @@ DEFAULT_COIN_SELECTION = {
     "min_price": 700,
     "max_price": 26666,
     "min_volume_24h": 1400000000,
-    "min_volume_1h": 10000000,
+    "min_volume_1h": 80000000,
     "min_tick_ratio": 0.035,
     "excluded_coins": ["KRW-ETHW", "KRW-ETHF", "KRW-XCORE", "KRW-GAS", "KRW-BTS"],
 }

--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -793,7 +793,7 @@ class MarketAnalyzer:
             min_price = settings.get('min_price', 700)
             max_price = settings.get('max_price', 26666)
             min_volume_24h = settings.get('min_volume_24h', 1400000000)
-            min_volume_1h = settings.get('min_volume_1h', 10000000)
+            min_volume_1h = settings.get('min_volume_1h', 80000000)
             min_tick_ratio = settings.get('min_tick_ratio', 0.035)
 
             logger.info(


### PR DESCRIPTION
## Summary
- raise minimum 1h trading volume threshold to 80,000,000 KRW

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684895a6e97c83299792f537a9fbc25a