### PR TITLE
Enable automatic pre-sell after manual buy

### DIFF
--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -1202,6 +1202,10 @@ class MarketAnalyzer:
         except Exception as e:
             logger.error(f"선매도 주문 처리 중 오류 발생: {str(e)}")
 
+    def place_pre_sell(self, market: str, buy_order: Dict) -> None:
+        """매수 후 선매도 주문을 실행하는 공개 메서드"""
+        self._place_pre_sell(market, buy_order)
+
     def get_candles(self, market: str, interval: str = 'minute15', count: int = 100) -> List[Dict]:
         """캔들 데이터 조회"""
         try:

--- a/tests/test_pre_sell_on_buy.py
+++ b/tests/test_pre_sell_on_buy.py
@@ -1,0 +1,19 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from web.app import handle_market_buy, market_analyzer
+
+class TestPreSellAfterBuy(unittest.TestCase):
+    def test_pre_sell_called_after_buy(self):
+        order = {'price': 1000, 'executed_volume': 1}
+        with patch('web.app.market_analyzer.buy_with_settings', return_value={'success': True, 'data': {'order_details': order}}) as mock_buy, \
+             patch('web.app.market_analyzer.place_pre_sell') as mock_pre_sell, \
+             patch('web.app.emit') as mock_emit, \
+             patch('web.app.market_analyzer.get_holdings', return_value={}), \
+             patch('web.app.market_analyzer.get_balance', return_value={}):
+            handle_market_buy({'market': 'KRW-BTC'})
+            mock_pre_sell.assert_called_once_with('KRW-BTC', order)
+            mock_emit.assert_any_call('market_buy_result', {'success': True, 'message': 'KRW-BTC 매수 주문이 완료되었습니다.', 'data': {'order_details': order}})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/web/app.py
+++ b/web/app.py
@@ -844,6 +844,9 @@ def handle_market_buy(data):
         result = market_analyzer.buy_with_settings(market)
 
         if result['success']:
+            order_details = result.get('data', {}).get('order_details')
+            if order_details:
+                market_analyzer.place_pre_sell(market, order_details)
             emit('market_buy_result', {
                 'success': True,
                 'message': f"{market} 매수 주문이 완료되었습니다.",


### PR DESCRIPTION
## Summary
- add a public `place_pre_sell` wrapper in `MarketAnalyzer`
- trigger pre-sell in `handle_market_buy`
- test that pre-sell is invoked when manual buy succeeds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848958dfe5883298576e09afddfe96c