### PR TITLE
Enable automatic pre-sell after manual buy

### DIFF
--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -1180,7 +1180,7 @@ class MarketAnalyzer:
                 logger.warning(f"{market} 매수 체결 수량이 없어 선매도 주문을 건너뜁니다.")
                 return
 
-            avg_price = float(buy_order['price']) / executed_volume
+            avg_price = float(buy_order.get('avg_price') or buy_order['price'])
             settings = self.get_sell_settings() or DEFAULT_SELL_SETTINGS.copy()
             tp_pct = float(settings.get('TP_PCT', 0))
             min_ticks = int(settings.get('MINIMUM_TICKS', 2))
@@ -1192,6 +1192,10 @@ class MarketAnalyzer:
                 target_price = avg_price + tick * min_ticks
                 target_price = math.ceil(target_price / tick) * tick
 
+            logger.info(
+                f"{market} 선매도 계산: avg_price={avg_price}, tick={tick}, target={target_price}"
+            )
+
             sell_success, sell_order = self.order_manager.place_limit_sell(
                 market, executed_volume, target_price
             )
@@ -1201,6 +1205,10 @@ class MarketAnalyzer:
                 logger.error(f"{market} 선매도 주문 실패")
         except Exception as e:
             logger.error(f"선매도 주문 처리 중 오류 발생: {str(e)}")
+
+    def place_pre_sell(self, market: str, buy_order: Dict) -> None:
+        """매수 후 선매도 주문을 실행하는 공개 메서드"""
+        self._place_pre_sell(market, buy_order)
 
     def get_candles(self, market: str, interval: str = 'minute15', count: int = 100) -> List[Dict]:
         """캔들 데이터 조회"""

--- a/tests/test_pre_sell_calc.py
+++ b/tests/test_pre_sell_calc.py
@@ -1,0 +1,26 @@
+import unittest
+from unittest.mock import MagicMock
+
+from core.market_analyzer import MarketAnalyzer
+
+class TestPreSellCalc(unittest.TestCase):
+    def setUp(self):
+        self.ma = MarketAnalyzer()
+        self.ma.order_manager = MagicMock()
+        self.ma.get_sell_settings = MagicMock(return_value={'TP_PCT': 0.18, 'MINIMUM_TICKS': 2})
+
+    def test_target_price_rounds_up(self):
+        order = {'price': 11420.0, 'executed_volume': 1}
+        self.ma._place_pre_sell('KRW-UNI', order)
+        args = self.ma.order_manager.place_limit_sell.call_args[0]
+        self.assertEqual(args, ('KRW-UNI', 1.0, 11450.0))
+
+    def test_minimum_ticks_enforced(self):
+        order = {'price': 200.0, 'executed_volume': 1}
+        self.ma.order_manager.place_limit_sell.reset_mock()
+        self.ma._place_pre_sell('KRW-XRP', order)
+        args = self.ma.order_manager.place_limit_sell.call_args[0]
+        self.assertEqual(args, ('KRW-XRP', 1.0, 202.0))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pre_sell_on_buy.py
+++ b/tests/test_pre_sell_on_buy.py
@@ -1,0 +1,19 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+from web.app import handle_market_buy, market_analyzer
+
+class TestPreSellAfterBuy(unittest.TestCase):
+    def test_pre_sell_called_after_buy(self):
+        order = {'price': 1000, 'executed_volume': 1}
+        with patch('web.app.market_analyzer.buy_with_settings', return_value={'success': True, 'data': {'order_details': order}}) as mock_buy, \
+             patch('web.app.market_analyzer.place_pre_sell') as mock_pre_sell, \
+             patch('web.app.emit') as mock_emit, \
+             patch('web.app.market_analyzer.get_holdings', return_value={}), \
+             patch('web.app.market_analyzer.get_balance', return_value={}):
+            handle_market_buy({'market': 'KRW-BTC'})
+            mock_pre_sell.assert_called_once_with('KRW-BTC', order)
+            mock_emit.assert_any_call('market_buy_result', {'success': True, 'message': 'KRW-BTC 매수 주문이 완료되었습니다.', 'data': {'order_details': order}})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/trading/bot/trading_bot.py
+++ b/trading/bot/trading_bot.py
@@ -143,7 +143,7 @@ class TradingBot:
                     if success and order_info:
                         executed_volume = float(order_info.get('executed_volume', 0))
                         if executed_volume:
-                            avg_price = float(order_info['price']) / executed_volume
+                            avg_price = float(order_info.get('avg_price') or order_info['price'])
 
                             tick = self._get_tick_size(avg_price)
                             tp_pct = float(self.sell_settings.get('TP_PCT', 0))

--- a/web/app.py
+++ b/web/app.py
@@ -844,6 +844,9 @@ def handle_market_buy(data):
         result = market_analyzer.buy_with_settings(market)
 
         if result['success']:
+            order_details = result.get('data', {}).get('order_details')
+            if order_details:
+                market_analyzer.place_pre_sell(market, order_details)
             emit('market_buy_result', {
                 'success': True,
                 'message': f"{market} 매수 주문이 완료되었습니다.",


### PR DESCRIPTION
## Summary
- fix average price calculation in pre-sell logic
- log calculated target prices for visibility
- use same fix in trading bot
- add tests for pre-sell target price calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848958dfe5883298576e09afddfe96c