### PR TITLE
Fix pre-sell order calculation

### DIFF
--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -1180,7 +1180,16 @@ class MarketAnalyzer:
                 logger.warning(f"{market} 매수 체결 수량이 없어 선매도 주문을 건너뜁니다.")
                 return
 
-            avg_price = float(buy_order['price']) / executed_volume
+            if 'avg_price' in buy_order and float(buy_order.get('avg_price', 0)):
+                avg_price = float(buy_order['avg_price'])
+            elif buy_order.get('trades'):
+                total_cost = sum(
+                    float(t['price']) * float(t['volume'])
+                    for t in buy_order.get('trades', [])
+                )
+                avg_price = total_cost / executed_volume
+            else:
+                avg_price = float(buy_order['price'])
             settings = self.get_sell_settings() or DEFAULT_SELL_SETTINGS.copy()
             tp_pct = float(settings.get('TP_PCT', 0))
             min_ticks = int(settings.get('MINIMUM_TICKS', 2))

--- a/tests/test_pre_sell_calculation.py
+++ b/tests/test_pre_sell_calculation.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import MagicMock
+from core.market_analyzer import MarketAnalyzer
+
+class TestPreSellCalculation(unittest.TestCase):
+    def test_target_price_from_avg_price(self):
+        analyzer = MarketAnalyzer.__new__(MarketAnalyzer)
+        analyzer.order_manager = MagicMock()
+        analyzer.get_sell_settings = MagicMock(return_value={'TP_PCT': 0.18, 'MINIMUM_TICKS': 2})
+        analyzer._get_tick_size = MarketAnalyzer._get_tick_size.__get__(analyzer)
+
+        buy_order = {
+            'price': '11420.0',
+            'avg_price': '11420.0',
+            'executed_volume': '0.61295972'
+        }
+
+        analyzer._place_pre_sell('KRW-UNI', buy_order)
+
+        analyzer.order_manager.place_limit_sell.assert_called_once()
+        market, volume, price = analyzer.order_manager.place_limit_sell.call_args[0]
+        self.assertEqual(market, 'KRW-UNI')
+        self.assertAlmostEqual(volume, float(buy_order['executed_volume']))
+        self.assertEqual(price, 11450.0)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/trading/bot/trading_bot.py
+++ b/trading/bot/trading_bot.py
@@ -143,7 +143,16 @@ class TradingBot:
                     if success and order_info:
                         executed_volume = float(order_info.get('executed_volume', 0))
                         if executed_volume:
-                            avg_price = float(order_info['price']) / executed_volume
+                            if 'avg_price' in order_info and float(order_info.get('avg_price', 0)):
+                                avg_price = float(order_info['avg_price'])
+                            elif order_info.get('trades'):
+                                total_cost = sum(
+                                    float(t['price']) * float(t['volume'])
+                                    for t in order_info.get('trades', [])
+                                )
+                                avg_price = total_cost / executed_volume
+                            else:
+                                avg_price = float(order_info['price'])
 
                             tick = self._get_tick_size(avg_price)
                             tp_pct = float(self.sell_settings.get('TP_PCT', 0))


### PR DESCRIPTION
## Summary
- calculate pre-sell target using avg_price from order
- handle avg_price in trading bot
- add regression test for pre-sell price

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848e9e867888329bf33dbdcefb02808