### PR TITLE
Adjust default coin selection

### DIFF
--- a/Development guides.md
+++ b/Development guides.md
@@ -947,7 +947,7 @@ MONITORING_INTERVAL=10
         "investment_amount": 7000,
         "max_coins": 7,
         "min_price": 700,
-        "max_price": 26666
+        "max_price": 70000
     },
     "notifications": {...}
 }

--- a/config.json
+++ b/config.json
@@ -6,9 +6,9 @@
         "max_coins": 3,
         "coin_selection": {
             "min_price": 700,
-            "max_price": 26666,
+            "max_price": 70000,
             "min_volume_24h": 1400000000,
-            "min_volume_1h": 70000000,
+            "min_volume_1h": 35000000,
             "min_tick_ratio": 0.035,
             "excluded_coins": [
                 "KRW-ETHW",

--- a/core/constants.py
+++ b/core/constants.py
@@ -1,9 +1,9 @@
 # Constants for global configuration
 DEFAULT_COIN_SELECTION = {
     "min_price": 700,
-    "max_price": 26666,
+    "max_price": 70000,
     "min_volume_24h": 1400000000,
-    "min_volume_1h": 80000000,
+    "min_volume_1h": 35000000,
     "min_tick_ratio": 0.035,
     "excluded_coins": ["KRW-ETHW", "KRW-ETHF", "KRW-XCORE", "KRW-GAS", "KRW-BTS"],
 }

--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -791,9 +791,9 @@ class MarketAnalyzer:
             trading = self.config.get('trading', {})
             settings = trading.get('coin_selection', {})
             min_price = settings.get('min_price', 700)
-            max_price = settings.get('max_price', 26666)
+            max_price = settings.get('max_price', 70000)
             min_volume_24h = settings.get('min_volume_24h', 1400000000)
-            min_volume_1h = settings.get('min_volume_1h', 80000000)
+            min_volume_1h = settings.get('min_volume_1h', 35000000)
             min_tick_ratio = settings.get('min_tick_ratio', 0.035)
 
             logger.info(


### PR DESCRIPTION
## Summary
- raise coin max price to 70k and lower hourly volume filter
- keep buy score threshold the same
- update documentation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68490549b6ec83299c305d790a0dc15d