### PR TITLE
Ensure pre-sell orders when checking holdings

### DIFF
--- a/core/upbit_api.py
+++ b/core/upbit_api.py
@@ -427,6 +427,15 @@ class UpbitAPI:
             self.logger.error(f"주문 정보 조회 실패: {str(e)}")
             return None
 
+    def get_open_orders(self, market: str, state: str = 'wait'):
+        """지정된 마켓의 미체결 주문 목록 조회"""
+        try:
+            params = {'market': market, 'state': state}
+            return self.send_request('GET', f'{self.server_url}/v1/orders', params)
+        except Exception as e:
+            self.logger.error(f"미체결 주문 조회 실패: {str(e)}")
+            return None
+
     def get_top_volume_tickers(self, base: str = "KRW", count: int = 100):
         """거래량 상위 티커 조회"""
         try:

--- a/tests/test_holdings_pre_sell.py
+++ b/tests/test_holdings_pre_sell.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import MagicMock
+
+from core.market_analyzer import MarketAnalyzer
+
+class TestHoldingsPreSell(unittest.TestCase):
+    def test_missing_pre_sell_is_created(self):
+        ma = MarketAnalyzer.__new__(MarketAnalyzer)
+        ma.order_manager = MagicMock()
+        ma.api = MagicMock()
+        ma._send_request = MagicMock(return_value=[
+            {'currency': 'UNI', 'balance': '1', 'avg_buy_price': '11420.0'},
+            {'currency': 'KRW', 'balance': '0'}
+        ])
+        ma.get_market_info = MagicMock(return_value={'trade_price': 11420.0})
+        ma.get_sell_settings = MagicMock(return_value={'TP_PCT': 0.18, 'MINIMUM_TICKS': 2})
+        ma._get_tick_size = MarketAnalyzer._get_tick_size.__get__(ma)
+        ma.invalid_markets = set()
+        ma.krw_balance = 0
+        ma.auto_bought = set()
+        ma.open_positions = [{'market': 'KRW-UNI', 'entry_price': 11420.0, 'volume': 1.0, 'sell_uuid': 'old'}]
+        ma.api.get_order_info.return_value = {'state': 'cancel'}
+        ma.order_manager.place_limit_sell.return_value = (True, {'uuid': 'new'})
+
+        holdings = ma.get_holdings()
+        ma.order_manager.place_limit_sell.assert_called_once()
+        self.assertEqual(ma.open_positions[0]['sell_uuid'], 'new')
+        self.assertIn('KRW-UNI', holdings)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- manage open pre-sell orders per entry price
- auto recreate pre-sell if missing when retrieving holdings
- expose open order query in UpbitAPI
- test automatic pre-sell recreation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684908f5c8688329b01c35169988251f