### PR TITLE
Implement monitoring pre-sell sync

### DIFF
--- a/core/monitoring_coin.py
+++ b/core/monitoring_coin.py
@@ -1,0 +1,83 @@
+import json
+import os
+from typing import Dict
+
+FILE_PATH = os.path.join(os.path.dirname(__file__), 'monitoring_coin.json')
+
+
+def _load() -> Dict[str, Dict]:
+    if os.path.exists(FILE_PATH):
+        try:
+            with open(FILE_PATH, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        except Exception:
+            return {}
+    return {}
+
+
+def _save(data: Dict[str, Dict]) -> None:
+    with open(FILE_PATH, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def record_buy(market: str, amount: float, pre_sell: bool = False) -> None:
+    """Record buy information for monitoring."""
+    data = _load()
+    data[market] = {'market': market, 'amount': amount, 'pre_sell': pre_sell}
+    _save(data)
+
+
+def update_pre_sell(market: str, pre_sell: bool = True) -> None:
+    """Update pre-sell status for a market."""
+    data = _load()
+    if market in data:
+        data[market]['pre_sell'] = pre_sell
+    else:
+        data[market] = {'market': market, 'amount': 0.0, 'pre_sell': pre_sell}
+    _save(data)
+
+
+def get_monitoring_coins(min_value: float = 5000) -> Dict[str, Dict]:
+    """Return monitoring coins excluding those below the min_value."""
+    data = _load()
+    return {
+        m: info
+        for m, info in data.items()
+        if info.get('amount', 0) >= min_value
+    }
+
+
+def sync_holdings(holdings: Dict[str, Dict], min_value: float = 5000) -> None:
+    """Ensure monitoring file contains all holdings."""
+    data = _load()
+    changed = False
+
+    # Add or update current holdings
+    for market, info in holdings.items():
+        amount = info.get('total_value')
+        if amount is None:
+            balance = info.get('balance', 0)
+            avg_price = info.get('avg_price', 0)
+            amount = balance * avg_price
+
+        if amount < min_value:
+            if market in data:
+                del data[market]
+                changed = True
+            continue
+
+        entry = data.get(market, {'market': market, 'pre_sell': False})
+        if abs(entry.get('amount', 0) - amount) > 1e-8 or market not in data:
+            entry['amount'] = amount
+            data[market] = entry
+            changed = True
+
+    # Remove markets no longer held
+    for market in list(data.keys()):
+        if market not in holdings and data[market].get('amount', 0) >= min_value:
+            del data[market]
+            changed = True
+
+    if changed:
+        _save(data)
+

--- a/tests/test_holdings_pre_sell.py
+++ b/tests/test_holdings_pre_sell.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from core.market_analyzer import MarketAnalyzer
+from unittest.mock import patch
 
 class TestHoldingsPreSell(unittest.TestCase):
     def test_missing_pre_sell_is_created(self):
@@ -22,7 +23,9 @@ class TestHoldingsPreSell(unittest.TestCase):
         ma.api.get_order_info.return_value = {'state': 'cancel'}
         ma.order_manager.place_limit_sell.return_value = (True, {'uuid': 'new'})
 
-        holdings = ma.get_holdings()
+        with patch('core.monitoring_coin.sync_holdings') as mock_sync:
+            holdings = ma.get_holdings()
+            mock_sync.assert_called_once()
         ma.order_manager.place_limit_sell.assert_called_once()
         self.assertEqual(ma.open_positions[0]['sell_uuid'], 'new')
         self.assertIn('KRW-UNI', holdings)

--- a/tests/test_monitoring_coin_sync.py
+++ b/tests/test_monitoring_coin_sync.py
@@ -1,0 +1,64 @@
+import unittest
+import json
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from core.market_analyzer import MarketAnalyzer
+
+class TestMonitoringCoinSync(unittest.TestCase):
+    def test_holdings_written_to_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = f"{tmpdir}/mon.json"
+            with patch('core.monitoring_coin.FILE_PATH', path):
+                ma = MarketAnalyzer.__new__(MarketAnalyzer)
+                ma.order_manager = MagicMock()
+                ma.api = MagicMock()
+                ma._send_request = MagicMock(return_value=[
+                    {'currency': 'UNI', 'balance': '1', 'avg_buy_price': '11420.0'},
+                    {'currency': 'KRW', 'balance': '0'}
+                ])
+                ma.get_market_info = MagicMock(return_value={'trade_price': 11420.0})
+                ma.invalid_markets = set()
+                ma._get_tick_size = MarketAnalyzer._get_tick_size.__get__(ma)
+                ma.get_sell_settings = MagicMock(return_value={'TP_PCT': 0.18, 'MINIMUM_TICKS': 2})
+                ma.krw_balance = 0
+                ma.auto_bought = set()
+                ma.open_positions = []
+                ma.api.get_order_info.return_value = {'state': 'wait'}
+                ma.order_manager.place_limit_sell.return_value = (True, {'uuid': 'x'})
+
+                with patch('core.monitoring_coin.update_pre_sell'):  # avoid file access
+                    holdings = ma.get_holdings()
+
+                with open(path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                self.assertIn('KRW-UNI', data)
+                self.assertAlmostEqual(data['KRW-UNI']['amount'], 11420.0)
+                self.assertFalse(data['KRW-UNI']['pre_sell'])
+                self.assertIn('KRW-UNI', holdings)
+
+    def test_removed_when_value_low(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = f"{tmpdir}/mon.json"
+            with open(path, 'w', encoding='utf-8') as f:
+                json.dump({'KRW-UNI': {'market': 'KRW-UNI', 'amount': 6000, 'pre_sell': False}}, f)
+            with patch('core.monitoring_coin.FILE_PATH', path):
+                ma = MarketAnalyzer.__new__(MarketAnalyzer)
+                ma.order_manager = MagicMock()
+                ma.api = MagicMock()
+                ma._send_request = MagicMock(return_value=[{'currency': 'KRW', 'balance': '0'}])
+                ma.invalid_markets = set()
+                ma.get_market_info = MagicMock()
+                ma.krw_balance = 0
+                ma.auto_bought = set()
+                ma.open_positions = []
+
+                holdings = ma.get_holdings()
+
+            with open(path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            self.assertNotIn('KRW-UNI', data)
+            self.assertEqual(holdings, {})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_monitoring_pre_sell_file.py
+++ b/tests/test_monitoring_pre_sell_file.py
@@ -1,0 +1,42 @@
+import unittest
+import json
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from core.market_analyzer import MarketAnalyzer
+
+class TestMonitoringPreSellFile(unittest.TestCase):
+    def test_pre_sell_created_from_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = f"{tmpdir}/mon.json"
+            with open(path, 'w', encoding='utf-8') as f:
+                json.dump({'KRW-UNI': {'market': 'KRW-UNI', 'amount': 11420.0, 'pre_sell': False}}, f)
+
+            with patch('core.monitoring_coin.FILE_PATH', path):
+                ma = MarketAnalyzer.__new__(MarketAnalyzer)
+                ma.order_manager = MagicMock()
+                ma.api = MagicMock()
+                ma._send_request = MagicMock(return_value=[
+                    {'currency': 'UNI', 'balance': '1', 'avg_buy_price': '11420.0'},
+                    {'currency': 'KRW', 'balance': '0'}
+                ])
+                ma.get_market_info = MagicMock(return_value={'trade_price': 11420.0})
+                ma.invalid_markets = set()
+                ma._get_tick_size = MarketAnalyzer._get_tick_size.__get__(ma)
+                ma.get_sell_settings = MagicMock(return_value={'TP_PCT': 0.18, 'MINIMUM_TICKS': 2})
+                ma.krw_balance = 0
+                ma.auto_bought = set()
+                ma.open_positions = []
+                ma.api.get_order_info.return_value = {'state': 'wait'}
+                ma.order_manager.place_limit_sell.return_value = (True, {'uuid': 'x'})
+
+                holdings = ma.get_holdings()
+
+            ma.order_manager.place_limit_sell.assert_called_once()
+            with open(path, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+            self.assertTrue(data['KRW-UNI']['pre_sell'])
+            self.assertIn('KRW-UNI', holdings)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep monitoring_coin.json synced with actual holdings, removing sold coins
- create pre-sell orders for coins listed in monitoring_coin.json when missing
- test cleanup of low-value holdings and pre-sell creation from file

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68490ebfa2f08329852fe9fd0f2daa9b