### PR TITLE
Implement monitoring cleanup on sell

### DIFF
--- a/core/monitoring_coin.py
+++ b/core/monitoring_coin.py
@@ -37,6 +37,14 @@ def update_pre_sell(market: str, pre_sell: bool = True) -> None:
     _save(data)
 
 
+def remove_market(market: str) -> None:
+    """Remove a market from monitoring."""
+    data = _load()
+    if market in data:
+        del data[market]
+        _save(data)
+
+
 def get_monitoring_coins(min_value: float = 5000) -> Dict[str, Dict]:
     """Return monitoring coins excluding those below the min_value."""
     data = _load()

--- a/tests/test_sell_update.py
+++ b/tests/test_sell_update.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from core.market_analyzer import MarketAnalyzer
+
+class TestSellUpdatesMonitoring(unittest.TestCase):
+    def test_monitoring_removed_on_sell(self):
+        ma = MarketAnalyzer.__new__(MarketAnalyzer)
+        ma.api = MagicMock()
+        ma.api.sell_market_order.return_value = {'uuid': 'x'}
+        ma.get_holdings = MagicMock(return_value={'KRW-UNI': {'balance': 1.0}})
+        ma.open_positions = [{'market': 'KRW-UNI', 'entry_price': 1000.0, 'volume': 1.0, 'sell_uuid': 'y'}]
+
+        with patch('core.monitoring_coin.remove_market') as mock_remove:
+            result = ma.sell_market_order('KRW-UNI')
+            mock_remove.assert_called_once_with('KRW-UNI')
+        self.assertTrue(result['success'])
+        self.assertEqual(ma.open_positions, [])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- update `monitoring_coin` with a `remove_market` helper
- add methods to `MarketAnalyzer` for selling coins which remove monitoring info
- test that selling a coin removes it from monitoring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849138d758483299fdae599e1c91c3c