### PR TITLE
Adjust monitoring coin handling

### DIFF
--- a/tests/test_holdings_pre_sell.py
+++ b/tests/test_holdings_pre_sell.py
@@ -26,8 +26,8 @@ class TestHoldingsPreSell(unittest.TestCase):
         with patch('core.monitoring_coin.sync_holdings') as mock_sync:
             holdings = ma.get_holdings()
             mock_sync.assert_called_once()
-        ma.order_manager.place_limit_sell.assert_called_once()
-        self.assertEqual(ma.open_positions[0]['sell_uuid'], 'new')
+        ma.order_manager.place_limit_sell.assert_not_called()
+        self.assertEqual(ma.open_positions[0]['sell_uuid'], 'old')
         self.assertIn('KRW-UNI', holdings)
 
 if __name__ == '__main__':

--- a/tests/test_monitoring_coin_sync.py
+++ b/tests/test_monitoring_coin_sync.py
@@ -25,23 +25,20 @@ class TestMonitoringCoinSync(unittest.TestCase):
                 ma.auto_bought = set()
                 ma.open_positions = []
                 ma.api.get_order_info.return_value = {'state': 'wait'}
-                ma.order_manager.place_limit_sell.return_value = (True, {'uuid': 'x'})
 
-                with patch('core.monitoring_coin.update_pre_sell'):  # avoid file access
-                    holdings = ma.get_holdings()
+                holdings = ma.get_holdings()
 
                 with open(path, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                 self.assertIn('KRW-UNI', data)
-                self.assertAlmostEqual(data['KRW-UNI']['amount'], 11420.0)
-                self.assertFalse(data['KRW-UNI']['pre_sell'])
+                self.assertEqual(data['KRW-UNI']['market'], 'KRW-UNI')
                 self.assertIn('KRW-UNI', holdings)
 
     def test_removed_when_value_low(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = f"{tmpdir}/mon.json"
             with open(path, 'w', encoding='utf-8') as f:
-                json.dump({'KRW-UNI': {'market': 'KRW-UNI', 'amount': 6000, 'pre_sell': False}}, f)
+                json.dump({'KRW-UNI': {'market': 'KRW-UNI', '매수체결가격': 1000, '매도주문가격': 1100}}, f)
             with patch('core.monitoring_coin.FILE_PATH', path):
                 ma = MarketAnalyzer.__new__(MarketAnalyzer)
                 ma.order_manager = MagicMock()

--- a/tests/test_monitoring_pre_sell_file.py
+++ b/tests/test_monitoring_pre_sell_file.py
@@ -10,7 +10,7 @@ class TestMonitoringPreSellFile(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = f"{tmpdir}/mon.json"
             with open(path, 'w', encoding='utf-8') as f:
-                json.dump({'KRW-UNI': {'market': 'KRW-UNI', 'amount': 11420.0, 'pre_sell': False}}, f)
+                json.dump({'KRW-UNI': {'market': 'KRW-UNI', '매수체결가격': 11420.0, '매도주문가격': 12000}}, f)
 
             with patch('core.monitoring_coin.FILE_PATH', path):
                 ma = MarketAnalyzer.__new__(MarketAnalyzer)
@@ -32,10 +32,10 @@ class TestMonitoringPreSellFile(unittest.TestCase):
 
                 holdings = ma.get_holdings()
 
-            ma.order_manager.place_limit_sell.assert_called_once()
+            ma.order_manager.place_limit_sell.assert_not_called()
             with open(path, 'r', encoding='utf-8') as f:
                 data = json.load(f)
-            self.assertTrue(data['KRW-UNI']['pre_sell'])
+            self.assertIn('KRW-UNI', data)
             self.assertIn('KRW-UNI', holdings)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- change monitoring coin storage to record buy and sell prices
- remove automatic pre-sell verification logic
- update get_holdings sync and tests for new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684965d111cc8329a062273a41146a36