### PR TITLE
Update 1h volume threshold

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
             "min_price": 700,
             "max_price": 70000,
             "min_volume_24h": 1400000000,
-            "min_volume_1h": 35000000,
+            "min_volume_1h": 10000000,
             "min_tick_ratio": 0.035,
             "excluded_coins": [
                 "KRW-ETHW",

--- a/core/constants.py
+++ b/core/constants.py
@@ -3,7 +3,7 @@ DEFAULT_COIN_SELECTION = {
     "min_price": 700,
     "max_price": 70000,
     "min_volume_24h": 1400000000,
-    "min_volume_1h": 35000000,
+    "min_volume_1h": 10000000,
     "min_tick_ratio": 0.035,
     "excluded_coins": ["KRW-ETHW", "KRW-ETHF", "KRW-XCORE", "KRW-GAS", "KRW-BTS"],
 }

--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -809,7 +809,7 @@ class MarketAnalyzer:
             min_price = settings.get('min_price', 700)
             max_price = settings.get('max_price', 70000)
             min_volume_24h = settings.get('min_volume_24h', 1400000000)
-            min_volume_1h = settings.get('min_volume_1h', 35000000)
+            min_volume_1h = settings.get('min_volume_1h', 10000000)
             min_tick_ratio = settings.get('min_tick_ratio', 0.035)
 
             logger.info(


### PR DESCRIPTION
## Summary
- lower the default 1h trading volume in coin selection from 35,000,000 to 10,000,000

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498af7973c8329876771782dbcc13b