### PR TITLE
Fix excluded market monitoring

### DIFF
--- a/core/monitoring_coin.py
+++ b/core/monitoring_coin.py
@@ -25,6 +25,8 @@ def _save(data: Dict[str, Dict]) -> None:
 
 def record_trade(market: str, buy_price: float, sell_price: float) -> None:
     """Record buy/sell information for monitoring."""
+    if market in EXCLUDED:
+        return
     data = _load()
     data[market] = {
         'market': market,
@@ -36,6 +38,8 @@ def record_trade(market: str, buy_price: float, sell_price: float) -> None:
 
 def update_sell_price(market: str, sell_price: float) -> None:
     """Update sell order price for a market."""
+    if market in EXCLUDED:
+        return
     data = _load()
     entry = data.get(market, {'market': market})
     entry['매도주문가격'] = sell_price

--- a/tests/test_record_trade_excluded.py
+++ b/tests/test_record_trade_excluded.py
@@ -1,0 +1,17 @@
+import unittest
+import os
+import tempfile
+from unittest.mock import patch
+
+from core.monitoring_coin import record_trade
+
+class TestRecordTradeExcluded(unittest.TestCase):
+    def test_excluded_market_not_written(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = f"{tmpdir}/mon.json"
+            with patch('core.monitoring_coin.FILE_PATH', path):
+                record_trade('KRW-ETHW', 1000.0, 1100.0)
+            self.assertFalse(os.path.exists(path))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- skip excluded markets in monitoring_coin.record_trade and update_sell_price
- ensure excluded markets do not create entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498bf6ca1483299296c24c5ac4c5a0