### PR TITLE
Trigger pre-sell after buy

### DIFF
--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -752,9 +752,6 @@ class MarketAnalyzer:
                         if result.get('success'):
                             self.auto_bought.add(coin['market'])
                             logger.info(f"{coin['market']} 자동 매수 성공")
-                            order = result.get('data', {}).get('order_details')
-                            if order:
-                                self._place_pre_sell(coin['market'], order)
                         else:
                             logger.error(
                                 f"{coin['market']} 자동 매수 실패: {result.get('error')}"
@@ -1169,6 +1166,7 @@ class MarketAnalyzer:
             settings = self.get_buy_settings() or DEFAULT_BUY_SETTINGS.copy()
             success, order = self.order_manager.buy_with_settings(market, settings)
             if success and order:
+                self._place_pre_sell(market, order)
                 return {
                     'success': True,
                     'data': {

--- a/tests/test_pre_sell_on_buy.py
+++ b/tests/test_pre_sell_on_buy.py
@@ -1,19 +1,27 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 from web.app import handle_market_buy, market_analyzer
 
 class TestPreSellAfterBuy(unittest.TestCase):
     def test_pre_sell_called_after_buy(self):
         order = {'price': 1000, 'executed_volume': 1}
-        with patch('web.app.market_analyzer.buy_with_settings', return_value={'success': True, 'data': {'order_details': order}}) as mock_buy, \
-             patch('web.app.market_analyzer.place_pre_sell') as mock_pre_sell, \
+        with patch('web.app.market_analyzer.order_manager.buy_with_settings', return_value=(True, order)) as mock_buy, \
+             patch('web.app.market_analyzer._place_pre_sell') as mock_pre_sell, \
              patch('web.app.emit') as mock_emit, \
              patch('web.app.market_analyzer.get_holdings', return_value={}), \
              patch('web.app.market_analyzer.get_balance', return_value={}):
             handle_market_buy({'market': 'KRW-BTC'})
             mock_pre_sell.assert_called_once_with('KRW-BTC', order)
-            mock_emit.assert_any_call('market_buy_result', {'success': True, 'message': 'KRW-BTC 매수 주문이 완료되었습니다.', 'data': {'order_details': order}})
+            mock_emit.assert_any_call('market_buy_result', {
+                'success': True,
+                'message': 'KRW-BTC 매수 주문이 완료되었습니다.',
+                'data': {
+                    'market': 'KRW-BTC',
+                    'order_type': 'limit_buy',
+                    'order_details': order
+                }
+            })
 
 if __name__ == '__main__':
     unittest.main()

--- a/web/app.py
+++ b/web/app.py
@@ -848,9 +848,6 @@ def handle_market_buy(data):
         result = market_analyzer.buy_with_settings(market)
 
         if result['success']:
-            order_details = result.get('data', {}).get('order_details')
-            if order_details:
-                market_analyzer.place_pre_sell(market, order_details)
             emit('market_buy_result', {
                 'success': True,
                 'message': f"{market} 매수 주문이 완료되었습니다.",


### PR DESCRIPTION
## Summary
- trigger pre-sell automatically from `buy_with_settings`
- remove redundant pre-sell calls
- update tests to account for new pre-sell behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498bf81fdc83299f963bb6c2b0533a