### PR TITLE
Update monitoring sync behavior

### DIFF
--- a/core/monitoring_coin.py
+++ b/core/monitoring_coin.py
@@ -61,19 +61,14 @@ def sync_holdings(holdings: Dict[str, Dict]) -> None:
     data = _load()
     changed = False
 
-    # Add missing holdings
-    for market in holdings.keys():
-        if market in EXCLUDED:
-            continue
-        if market not in data:
-            data[market] = {'market': market}
-            changed = True
-
-    # Remove markets no longer held
+    # Remove markets no longer held or excluded
     for market in list(data.keys()):
         if market not in holdings or market in EXCLUDED:
             del data[market]
             changed = True
+
+    # Do not create placeholder entries for new holdings. They will be
+    # recorded only after a trade occurs via ``record_trade``.
 
     if changed:
         _save(data)

--- a/tests/test_monitoring_coin_sync.py
+++ b/tests/test_monitoring_coin_sync.py
@@ -1,6 +1,7 @@
 import unittest
 import json
 import tempfile
+import os
 from unittest.mock import MagicMock, patch
 
 from core.market_analyzer import MarketAnalyzer
@@ -28,10 +29,7 @@ class TestMonitoringCoinSync(unittest.TestCase):
 
                 holdings = ma.get_holdings()
 
-                with open(path, 'r', encoding='utf-8') as f:
-                    data = json.load(f)
-                self.assertIn('KRW-UNI', data)
-                self.assertEqual(data['KRW-UNI']['market'], 'KRW-UNI')
+                self.assertFalse(os.path.exists(path))
                 self.assertIn('KRW-UNI', holdings)
 
     def test_removed_when_value_low(self):


### PR DESCRIPTION
## Summary
- avoid writing placeholder data to monitoring file
- update monitoring coin sync test accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68498bf99a4883298424e5fb98df4941