### PR TITLE
Enable Telegram log forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ UPBIT_SECRET_KEY=your_secret_key
 TELEGRAM_BOT_TOKEN=your_bot_token
 TELEGRAM_CHAT_ID=your_chat_id
 LOG_LEVEL=INFO
+TELEGRAM_LOG_LEVEL=ERROR
 ```
 실제 키로 교체한 후 저장하세요.
 

--- a/config/logging_config.py
+++ b/config/logging_config.py
@@ -2,6 +2,7 @@ import os
 import logging
 from concurrent_log_handler import ConcurrentRotatingFileHandler
 from datetime import datetime
+from core.telegram_log_handler import TelegramLogHandler
 
 def setup_logging():
     """공통 로깅 설정을 초기화한다."""
@@ -46,6 +47,17 @@ def setup_logging():
     # 핸들러 추가
     logger.addHandler(file_handler)
     logger.addHandler(console_handler)
+
+    # 텔레그램 핸들러 (옵션)
+    bot_token = os.getenv('TELEGRAM_BOT_TOKEN')
+    chat_id = os.getenv('TELEGRAM_CHAT_ID')
+    if bot_token and chat_id:
+        telegram_level = os.getenv('TELEGRAM_LOG_LEVEL', 'ERROR').upper()
+        telegram_handler = TelegramLogHandler(
+            level=getattr(logging, telegram_level, logging.ERROR)
+        )
+        telegram_handler.setFormatter(formatter)
+        logger.addHandler(telegram_handler)
 
     # suppress noisy library logs
     logging.getLogger('werkzeug').setLevel(logging.WARNING)

--- a/core/telegram_log_handler.py
+++ b/core/telegram_log_handler.py
@@ -1,0 +1,24 @@
+import logging
+import os
+from .telegram_notifier import TelegramNotifier
+
+class TelegramLogHandler(logging.Handler):
+    """Logging handler that sends log records to Telegram."""
+    def __init__(self, level=logging.ERROR):
+        super().__init__(level)
+        try:
+            self.notifier = TelegramNotifier()
+        except Exception:
+            self.notifier = None
+
+    def emit(self, record: logging.LogRecord):
+        if not self.notifier:
+            return
+        try:
+            msg = self.format(record)
+            # Limit message length for Telegram
+            if len(msg) > 3500:
+                msg = msg[:3500] + '...'
+            self.notifier.send_message_sync(msg)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- add `TelegramLogHandler` to forward logs
- wire the handler in `setup_logging`
- document new `TELEGRAM_LOG_LEVEL` setting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498f5e8b9883298da91c2f33c0cec1