### PR TITLE
Implement Telegram log cooldown

### DIFF
--- a/core/telegram_log_handler.py
+++ b/core/telegram_log_handler.py
@@ -1,15 +1,18 @@
 import logging
-import os
+from datetime import datetime, timedelta
 from .telegram_notifier import TelegramNotifier
 
 class TelegramLogHandler(logging.Handler):
     """Logging handler that sends log records to Telegram."""
-    def __init__(self, level=logging.ERROR):
+
+    def __init__(self, level=logging.ERROR, cooldown_minutes: int = 10):
         super().__init__(level)
         try:
             self.notifier = TelegramNotifier()
         except Exception:
             self.notifier = None
+        self.cooldown = timedelta(minutes=cooldown_minutes)
+        self._last_sent = {}
 
     def emit(self, record: logging.LogRecord):
         if not self.notifier:
@@ -19,6 +22,12 @@ class TelegramLogHandler(logging.Handler):
             # Limit message length for Telegram
             if len(msg) > 3500:
                 msg = msg[:3500] + '...'
+            key = (record.name, record.levelno, record.getMessage())
+            now = datetime.now()
+            last_time = self._last_sent.get(key)
+            if last_time and now - last_time < self.cooldown:
+                return
+            self._last_sent[key] = now
             self.notifier.send_message_sync(msg)
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- throttle repeated Telegram logs with a default 10 minute cooldown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849926267248329b91fd9d4f93e1782