### PR TITLE
Modify tick size for prices below 1000

### DIFF
--- a/core/market_analyzer.py
+++ b/core/market_analyzer.py
@@ -430,7 +430,7 @@ class MarketAnalyzer:
         if price < 100:
             return 0.1
         if price < 1000:
-            return 1
+            return 0.1
         if price < 10000:
             return 5
         if price < 100000:

--- a/tests/test_pre_sell_calc.py
+++ b/tests/test_pre_sell_calc.py
@@ -20,7 +20,7 @@ class TestPreSellCalc(unittest.TestCase):
         self.ma.order_manager.place_limit_sell.reset_mock()
         self.ma._place_pre_sell('KRW-XRP', order)
         args = self.ma.order_manager.place_limit_sell.call_args[0]
-        self.assertEqual(args, ('KRW-XRP', 1.0, 202.0))
+        self.assertEqual(args, ('KRW-XRP', 1.0, 200.4))
 
 if __name__ == '__main__':
     unittest.main()

--- a/trading/bot/trading_bot.py
+++ b/trading/bot/trading_bot.py
@@ -49,7 +49,7 @@ class TradingBot:
         if price < 100:
             return 0.1
         if price < 1000:
-            return 1
+            return 0.1
         if price < 10000:
             return 5
         if price < 100000:


### PR DESCRIPTION
## Summary
- adjust `_get_tick_size` so prices below 1000 KRW use a 0.1 tick size
- mirror tick size update in trading bot
- update unit test expectation for pre-sell price

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'concurrent_log_handler')*

------
https://chatgpt.com/codex/tasks/task_e_684991a5ac788329bdb310a1417fd78c